### PR TITLE
Hook up to live market data

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -1,6 +1,6 @@
 from functools import reduce
 from model import Cash, Trade, Instrument, Option, LiveDataProvider, Quote, Position
-from typing import Iterable, Optional, Tuple
+from typing import Dict, Iterable, Optional, Tuple
 
 import asyncio
 
@@ -23,7 +23,7 @@ def realizedBasisForSymbol(symbol: str,
 
 async def liveValuesForPositions(positions: Iterable[Position],
                                  dataProvider: LiveDataProvider
-                                 ) -> Iterable[Tuple[Position, Cash]]:
+                                 ) -> Dict[Position, Cash]:
     def priceFromQuote(q: Quote, p: Position) -> Cash:
         # For a long position, the value should be what the market is willing to pay right now.
         # For a short position, the value should be what the market is asking to be paid right now.
@@ -33,6 +33,8 @@ async def liveValuesForPositions(positions: Iterable[Position],
         else:
             return q.bid
 
-    return ((p,
-             priceFromQuote(await dataProvider.fetchQuote(p.instrument), p) *
-             p.quantity) for p in positions)
+    return {
+        p: priceFromQuote(await dataProvider.fetchQuote(p.instrument), p) *
+        p.quantity
+        for p in positions
+    }

--- a/analysis.py
+++ b/analysis.py
@@ -2,8 +2,6 @@ from functools import reduce
 from model import Cash, Trade, Instrument, Option, LiveDataProvider, Quote, Position
 from typing import Dict, Iterable, Optional, Tuple
 
-import asyncio
-
 
 def tradeAffectsSymbol(trade: Trade, symbol: str) -> bool:
     return (isinstance(trade.instrument, Option)
@@ -21,9 +19,9 @@ def realizedBasisForSymbol(symbol: str,
                   None)
 
 
-async def liveValuesForPositions(positions: Iterable[Position],
-                                 dataProvider: LiveDataProvider
-                                 ) -> Dict[Position, Cash]:
+def liveValuesForPositions(positions: Iterable[Position],
+                           dataProvider: LiveDataProvider
+                           ) -> Dict[Position, Cash]:
     def priceFromQuote(q: Quote, p: Position) -> Cash:
         # For a long position, the value should be what the market is willing to pay right now.
         # For a short position, the value should be what the market is asking to be paid right now.
@@ -34,7 +32,7 @@ async def liveValuesForPositions(positions: Iterable[Position],
             return q.bid
 
     return {
-        p: priceFromQuote(await dataProvider.fetchQuote(p.instrument), p) *
-        p.quantity
+        p:
+        priceFromQuote(dataProvider.fetchQuote(p.instrument), p) * p.quantity
         for p in positions
     }

--- a/analysis.py
+++ b/analysis.py
@@ -37,6 +37,6 @@ def liveValuesForPositions(positions: Iterable[Position],
         if not price:
             continue
 
-        result[p] = price
+        result[p] = price * p.quantity
 
     return result

--- a/analysis.py
+++ b/analysis.py
@@ -36,6 +36,6 @@ def liveValuesForPositions(positions: Iterable[Position],
         if not price:
             continue
 
-        result[p] = price * p.quantity
+        result[p] = price * p.quantity * p.instrument.multiplier
 
     return result

--- a/analysis.py
+++ b/analysis.py
@@ -25,11 +25,10 @@ def liveValuesForPositions(positions: Iterable[Position],
     def priceFromQuote(q: Quote, p: Position) -> Optional[Cash]:
         # For a long position, the value should be what the market is willing to pay right now.
         # For a short position, the value should be what the market is asking to be paid right now.
-        # TODO: Use order depth if available?
         if p.quantity < 0:
-            return q.ask or q.last or q.bid
+            return q.ask or q.last or q.bid or q.close
         else:
-            return q.bid or q.last or q.ask
+            return q.bid or q.last or q.ask or q.close
 
     result = {}
     for p in positions:

--- a/bankroll.py
+++ b/bankroll.py
@@ -10,6 +10,7 @@ import analysis
 import asyncio
 import ibkr
 import fidelity
+import logging
 import schwab
 import vanguard
 
@@ -22,6 +23,12 @@ parser.add_argument(
     default=False,
     action='store_true')
 parser.add_argument('--no-lenient', dest='lenient', action='store_false')
+parser.add_argument('-v',
+                    '--verbose',
+                    help='More logging.',
+                    dest='verbose',
+                    default=False,
+                    action='store_true')
 
 ibGroup = parser.add_argument_group(
     'IB', 'Options for importing data from Interactive Brokers.')
@@ -144,6 +151,9 @@ tradesParser = subparsers.add_parser(
 
 if __name__ == '__main__':
     args = parser.parse_args()
+    if args.verbose:
+        logging.basicConfig(level=logging.INFO)
+
     if not args.command:
         parser.print_usage()
         quit(1)

--- a/bankroll.py
+++ b/bankroll.py
@@ -109,7 +109,7 @@ def printPositions(args: Namespace) -> None:
         if p in values:
             print('\tMarket value: {}'.format(values[p]))
         elif args.live_value:
-            logging.warning('\tCould not fetch market value for {}'.format(
+            logging.warning('Could not fetch market value for {}'.format(
                 p.instrument))
 
         if not isinstance(p.instrument, Stock):

--- a/bankroll.py
+++ b/bankroll.py
@@ -109,7 +109,7 @@ def printPositions(args: Namespace) -> None:
         if p in values:
             print('\tMarket value: {}'.format(values[p]))
         elif args.live_value:
-            logging.warn('\tCould not fetch market value for {}'.format(
+            logging.warning('\tCould not fetch market value for {}'.format(
                 p.instrument))
 
         if not isinstance(p.instrument, Stock):

--- a/bankroll.py
+++ b/bankroll.py
@@ -109,7 +109,8 @@ def printPositions(args: Namespace) -> None:
         if p in values:
             print('\tMarket value: {}'.format(values[p]))
         elif args.live_value:
-            logging.warn('\tCould not fetch market value for {}'.format(p.instrument))
+            logging.warn('\tCould not fetch market value for {}'.format(
+                p.instrument))
 
         if not isinstance(p.instrument, Stock):
             continue

--- a/bankroll.py
+++ b/bankroll.py
@@ -105,7 +105,7 @@ def printPositions(args: Namespace) -> None:
     for p in sorted(positions, key=lambda p: p.instrument):
         print(p)
 
-        if values:
+        if p in values:
             print('\tMarket value: {}'.format(values[p]))
 
         if not isinstance(p.instrument, Stock):

--- a/bankroll.py
+++ b/bankroll.py
@@ -93,10 +93,8 @@ dataProvider: Optional[LiveDataProvider] = None
 async def printPositions(args: Namespace) -> None:
     if args.live_value:
         assert dataProvider, 'Live data connection required to fetch market values'
-
-        values: Dict[Position, Cash] = dict(
-            await analysis.liveValuesForPositions(positions,
-                                                  dataProvider=dataProvider))
+        values = await analysis.liveValuesForPositions(
+            positions, dataProvider=dataProvider)
 
     for p in sorted(positions, key=lambda p: p.instrument):
         print(p)
@@ -195,4 +193,4 @@ if __name__ == '__main__':
         trades += ibkr.parseTrades(args.ibtrades, lenient=args.lenient)
 
     positions = list(combinePositions(positions))
-    await commands[args.command](args)
+    asyncio.run(commands[args.command](args))

--- a/bankroll.py
+++ b/bankroll.py
@@ -7,7 +7,6 @@ from pathlib import Path
 from typing import Dict, Iterable, List, Optional
 
 import analysis
-import asyncio
 import ibkr
 import fidelity
 import logging
@@ -97,11 +96,11 @@ trades: List[Trade] = []
 dataProvider: Optional[LiveDataProvider] = None
 
 
-async def printPositions(args: Namespace) -> None:
+def printPositions(args: Namespace) -> None:
     if args.live_value:
         assert dataProvider, 'Live data connection required to fetch market values'
-        values = await analysis.liveValuesForPositions(
-            positions, dataProvider=dataProvider)
+        values = analysis.liveValuesForPositions(positions,
+                                                 dataProvider=dataProvider)
 
     for p in sorted(positions, key=lambda p: p.instrument):
         print(p)
@@ -120,7 +119,7 @@ async def printPositions(args: Namespace) -> None:
             print('\tRealized basis: {}'.format(realizedBasis))
 
 
-async def printTrades(args: Namespace) -> None:
+def printTrades(args: Namespace) -> None:
     for t in sorted(trades, key=lambda t: t.date, reverse=True):
         print(t)
 
@@ -203,4 +202,4 @@ if __name__ == '__main__':
         trades += ibkr.parseTrades(args.ibtrades, lenient=args.lenient)
 
     positions = list(combinePositions(positions))
-    asyncio.run(commands[args.command](args))
+    commands[args.command](args)

--- a/bankroll.py
+++ b/bankroll.py
@@ -97,6 +97,7 @@ dataProvider: Optional[LiveDataProvider] = None
 
 
 def printPositions(args: Namespace) -> None:
+    values: Dict[Position, Cash] = {}
     if args.live_value:
         assert dataProvider, 'Live data connection required to fetch market values'
         values = analysis.liveValuesForPositions(positions,

--- a/bankroll.py
+++ b/bankroll.py
@@ -108,6 +108,8 @@ def printPositions(args: Namespace) -> None:
 
         if p in values:
             print('\tMarket value: {}'.format(values[p]))
+        elif args.live_value:
+            logging.warn('\tCould not fetch market value for {}'.format(p.instrument))
 
         if not isinstance(p.instrument, Stock):
             continue

--- a/fidelity.py
+++ b/fidelity.py
@@ -69,6 +69,7 @@ def parseOptionsPosition(description: str) -> Option:
     year = datetime.strptime(match['year'], '%y').year
 
     return Option(underlying=match['underlying'],
+                  currency=Currency.USD,
                   expiration=date(year, month, int(match['day'])),
                   optionType=optionType,
                   strike=Decimal(match['strike']))
@@ -88,8 +89,8 @@ def parsePositions(path: Path, lenient: bool = False) -> List[Position]:
             rowFilter=lambda r: r[0:7])
 
         instrumentBySection: Dict[CSVSectionCriterion, InstrumentFactory] = {
-            stocksCriterion: lambda p: Stock(p.symbol),
-            bondsCriterion: lambda p: Bond(p.symbol),
+            stocksCriterion: lambda p: Stock(p.symbol, currency=Currency.USD),
+            bondsCriterion: lambda p: Bond(p.symbol, currency=Currency.USD),
             optionsCriterion: lambda p: parseOptionsPosition(p.description),
         }
 
@@ -141,6 +142,7 @@ def parseOptionTransaction(symbol: str) -> Option:
         optionType = OptionType.CALL
 
     return Option(underlying=match['underlying'],
+                  currency=Currency.USD,
                   expiration=datetime.strptime(match['date'], '%y%m%d').date(),
                   optionType=optionType,
                   strike=Decimal(match['strike']))
@@ -150,9 +152,9 @@ def guessInstrumentFromSymbol(symbol: str) -> Instrument:
     if re.search(r'[0-9]+(C|P)[0-9]+$', symbol):
         return parseOptionTransaction(symbol)
     elif Bond.validBondSymbol(symbol):
-        return Bond(symbol)
+        return Bond(symbol, currency=Currency.USD)
     else:
-        return Stock(symbol)
+        return Stock(symbol, currency=Currency.USD)
 
 
 def forceParseFidelityTransaction(t: FidelityTransaction,

--- a/ibkr.py
+++ b/ibkr.py
@@ -326,6 +326,7 @@ class IBDataProvider(LiveDataProvider):
         bid: Optional[Cash] = None
         ask: Optional[Cash] = None
         last: Optional[Cash] = None
+        close: Optional[Cash] = None
 
         if (ticker.bid
                 and math.isfinite(ticker.bid)) and not ticker.bidSize == 0:
@@ -339,5 +340,8 @@ class IBDataProvider(LiveDataProvider):
                 and math.isfinite(ticker.last)) and not ticker.lastSize == 0:
             last = Cash(currency=instrument.currency,
                         quantity=Decimal(ticker.last))
+        if ticker.close and math.isfinite(ticker.close):
+            close = Cash(currency=instrument.currency,
+                         quantity=Decimal(ticker.close))
 
-        return Quote(bid=bid, ask=ask, last=last)
+        return Quote(bid=bid, ask=ask, last=last, close=close)

--- a/ibkr.py
+++ b/ibkr.py
@@ -217,20 +217,18 @@ def downloadTrades(token: str, queryID: int,
 
 
 def stockContract(stock: Stock) -> IB.Contract:
-    # TODO: Need currency here
-    return IB.Stock(symbol=stock.symbol)
+    return IB.Stock(symbol=stock.symbol, currency=stock.currency.value)
 
 
 def bondContract(bond: Bond) -> IB.Contract:
-    # TODO: Need currency here
-    return IB.Bond(symbol=bond.symbol)
+    return IB.Bond(symbol=bond.symbol, currency=bond.currency.value)
 
 
 def optionContract(option: Option) -> IB.Contract:
     lastTradeDate = option.expiration.strftime('%Y%m%d')
 
-    # TODO: Need currency here
     return IB.Option(symbol=option.symbol,
+                     currency=option.currency.value,
                      lastTradeDateOrContractMonth=lastTradeDate,
                      right=option.optionType.value)
 
@@ -238,19 +236,18 @@ def optionContract(option: Option) -> IB.Contract:
 def fopContract(option: FutureOption) -> IB.Contract:
     lastTradeDate = option.expiration.strftime('%Y%m%d')
 
-    # TODO: Need currency here
     return IB.FuturesOption(symbol=option.symbol,
+                            currency=option.currency.value,
                             lastTradeDateOrContractMonth=lastTradeDate,
                             right=option.optionType.value)
 
 
 def futuresContract(future: Future) -> IB.Contract:
-    # TODO: Need currency here
-    return IB.Future(symbol=future.symbol)
+    return IB.Future(symbol=future.symbol, currency=option.currency.value)
 
 
 def forexContract(forex: Forex) -> IB.Contract:
-    return IB.Forex(pair=forex.symbol)
+    return IB.Forex(pair=forex.symbol, currency=forex.currency.value)
 
 
 def contract(instrument: Instrument) -> IB.Contract:
@@ -280,16 +277,12 @@ class IBDataProvider(LiveDataProvider):
         con = contract(instrument)
         self._client.qualifyContracts(con)
 
-        if not con.currency:
-            raise RuntimeError(
-                'Did not receive a currency for instrument {} as contract: {}'.
-                format(instrument, con))
-
-        currency = Currency[con.currency]
-
         tickers = self._client.reqTickers(con)
         tick = tickers[0]
 
-        return Quote(bid=Cash(currency=currency, quantity=Decimal(tick.bid)),
-                     ask=Cash(currency=currency, quantity=Decimal(tick.ask)),
-                     last=Cash(currency=currency, quantity=Decimal(tick.last)))
+        return Quote(bid=Cash(currency=instrument.currency,
+                              quantity=Decimal(tick.bid)),
+                     ask=Cash(currency=instrument.currency,
+                              quantity=Decimal(tick.ask)),
+                     last=Cash(currency=instrument.currency,
+                               quantity=Decimal(tick.last)))

--- a/ibkr.py
+++ b/ibkr.py
@@ -322,13 +322,13 @@ class IBDataProvider(LiveDataProvider):
         ask: Optional[Cash] = None
         last: Optional[Cash] = None
 
-        if ticker.bid and math.isfinite(ticker.bid):
+        if (ticker.bid and math.isfinite(ticker.bid)) and not ticker.bidSize == 0:
             bid = Cash(currency=instrument.currency,
                        quantity=Decimal(ticker.bid))
-        if ticker.ask and math.isfinite(ticker.ask):
+        if (ticker.ask and math.isfinite(ticker.ask)) and not ticker.askSize == 0:
             ask = Cash(currency=instrument.currency,
                        quantity=Decimal(ticker.ask))
-        if ticker.last and math.isfinite(ticker.last):
+        if (ticker.last and math.isfinite(ticker.last)) and not ticker.lastSize == 0:
             last = Cash(currency=instrument.currency,
                         quantity=Decimal(ticker.last))
 

--- a/ibkr.py
+++ b/ibkr.py
@@ -201,7 +201,8 @@ def parseTradeConfirm(trade: IBTradeConfirm) -> Trade:
         instrument = parseFutureOptionTrade(trade)
     else:
         raise ValueError(
-            'Unrecognized/unsupported security type in position: {}'.format(p))
+            'Unrecognized/unsupported security type in trade: {}'.format(
+                trade))
 
     flagsByCode = {
         'O': TradeFlags.OPEN,

--- a/ibkr.py
+++ b/ibkr.py
@@ -322,13 +322,16 @@ class IBDataProvider(LiveDataProvider):
         ask: Optional[Cash] = None
         last: Optional[Cash] = None
 
-        if (ticker.bid and math.isfinite(ticker.bid)) and not ticker.bidSize == 0:
+        if (ticker.bid
+                and math.isfinite(ticker.bid)) and not ticker.bidSize == 0:
             bid = Cash(currency=instrument.currency,
                        quantity=Decimal(ticker.bid))
-        if (ticker.ask and math.isfinite(ticker.ask)) and not ticker.askSize == 0:
+        if (ticker.ask
+                and math.isfinite(ticker.ask)) and not ticker.askSize == 0:
             ask = Cash(currency=instrument.currency,
                        quantity=Decimal(ticker.ask))
-        if (ticker.last and math.isfinite(ticker.last)) and not ticker.lastSize == 0:
+        if (ticker.last
+                and math.isfinite(ticker.last)) and not ticker.lastSize == 0:
             last = Cash(currency=instrument.currency,
                         quantity=Decimal(ticker.last))
 

--- a/ibkr.py
+++ b/ibkr.py
@@ -5,7 +5,6 @@ from parsetools import lenientParse
 from pathlib import Path
 from typing import Awaitable, Callable, Dict, List, NamedTuple, Type
 
-import asyncio
 import ib_insync as IB
 import re
 
@@ -267,9 +266,9 @@ class IBDataProvider(LiveDataProvider):
         self._client = client
         super().__init__()
 
-    async def fetchQuote(self, instrument: Instrument) -> Quote:
+    def fetchQuote(self, instrument: Instrument) -> Quote:
         con = contract(instrument)
-        await self._client.qualifyContractsAsync(con)
+        self._client.qualifyContracts(con)
 
         if not con.currency:
             raise RuntimeError(
@@ -278,7 +277,7 @@ class IBDataProvider(LiveDataProvider):
 
         currency = Currency[con.currency]
 
-        tickers = await self._client.reqTickersAsync(con)
+        tickers = self._client.reqTickers(con)
         tick = tickers[0]
 
         return Quote(bid=Cash(currency=currency, quantity=Decimal(tick.bid)),

--- a/ibkr.py
+++ b/ibkr.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 from decimal import Decimal
+from enum import IntEnum
 from model import Currency, Cash, Instrument, Stock, Bond, Option, OptionType, FutureOption, Future, Forex, Position, TradeFlags, Trade, LiveDataProvider, Quote
 from parsetools import lenientParse
 from pathlib import Path
@@ -293,12 +294,24 @@ def contract(instrument: Instrument) -> IB.Contract:
             repr(instrument)))
 
 
+# https://interactivebrokers.github.io/tws-api/market_data_type.html
+class MarketDataType(IntEnum):
+    LIVE = 1
+    FROZEN = 2
+    DELAYED = 3
+    DELAYED_FROZEN = 4
+
+
 class IBDataProvider(LiveDataProvider):
     def __init__(self, client: IB.IB):
         self._client = client
         super().__init__()
 
-    def fetchQuote(self, instrument: Instrument) -> Quote:
+    def fetchQuote(self,
+                   instrument: Instrument,
+                   dataType: MarketDataType = MarketDataType.FROZEN) -> Quote:
+        self._client.reqMarketDataType(dataType.value)
+
         con = contract(instrument)
         self._client.qualifyContracts(con)
 

--- a/ibkr.py
+++ b/ibkr.py
@@ -204,3 +204,58 @@ def downloadTrades(token: str, queryID: int,
                    lenient: bool = False) -> List[Trade]:
     return tradesFromReport(IB.FlexReport(token=token, queryId=queryID),
                             lenient=lenient)
+
+
+def stockContract(stock: Stock) -> IB.Contract:
+    # TODO: Need currency here
+    return IB.Stock(symbol=stock.symbol)
+
+
+def bondContract(bond: Bond) -> IB.Contract:
+    # TODO: Need currency here
+    return IB.Bond(symbol=bond.symbol)
+
+
+def optionContract(option: Option) -> IB.Contract:
+    lastTradeDate = option.expiration.strftime('%Y%m%d')
+
+    # TODO: Need currency here
+    return IB.Option(symbol=option.symbol,
+                     lastTradeDateOrContractMonth=lastTradeDate,
+                     right=option.optionType.value)
+
+
+def fopContract(option: FutureOption) -> IB.Contract:
+    lastTradeDate = option.expiration.strftime('%Y%m%d')
+
+    # TODO: Need currency here
+    return IB.FuturesOption(symbol=option.symbol,
+                            lastTradeDateOrContractMonth=lastTradeDate,
+                            right=option.optionType.value)
+
+
+def futuresContract(future: Future) -> IB.Contract:
+    # TODO: Need currency here
+    return IB.Future(symbol=future.symbol)
+
+
+def forexContract(forex: Forex) -> IB.Contract:
+    return IB.Forex(pair=forex.symbol)
+
+
+def contract(instrument: Instrument) -> IB.Contract:
+    if isinstance(instrument, Stock):
+        return stockContract(instrument)
+    elif isinstance(instrument, Bond):
+        return bondContract(instrument)
+    elif isinstance(instrument, FutureOption):
+        return fopContract(instrument)
+    elif isinstance(instrument, Option):
+        return optionContract(instrument)
+    elif isinstance(instrument, Future):
+        return futuresContract(instrument)
+    elif isinstance(instrument, Forex):
+        return forexContract(instrument)
+    else:
+        raise ValueError('Unexpected type of instrument: {}'.format(
+            repr(instrument)))

--- a/ibkr.py
+++ b/ibkr.py
@@ -309,7 +309,8 @@ class IBDataProvider(LiveDataProvider):
 
     def fetchQuote(self,
                    instrument: Instrument,
-                   dataType: MarketDataType = MarketDataType.FROZEN) -> Quote:
+                   dataType: MarketDataType = MarketDataType.DELAYED_FROZEN
+                   ) -> Quote:
         self._client.reqMarketDataType(dataType.value)
 
         con = contract(instrument)

--- a/ibkr.py
+++ b/ibkr.py
@@ -249,11 +249,15 @@ def bondContract(bond: Bond) -> IB.Contract:
 def optionContract(option: Option) -> IB.Contract:
     lastTradeDate = option.expiration.strftime('%Y%m%d')
 
-    return IB.Option(symbol=option.symbol,
-                     exchange='SMART',
-                     currency=option.currency.value,
-                     lastTradeDateOrContractMonth=lastTradeDate,
-                     right=option.optionType.value)
+    return IB.Option(
+        localSymbol=option.symbol,
+        exchange='SMART',
+        currency=option.currency.value,
+        lastTradeDateOrContractMonth=lastTradeDate,
+        right=option.optionType.value,
+        strike=float(option.strike),
+        # TODO: Support non-standard multipliers
+        multiplier='100')
 
 
 def fopContract(option: FutureOption) -> IB.Contract:

--- a/ibkr.py
+++ b/ibkr.py
@@ -219,17 +219,22 @@ def downloadTrades(token: str, queryID: int,
 
 
 def stockContract(stock: Stock) -> IB.Contract:
-    return IB.Stock(symbol=stock.symbol, currency=stock.currency.value)
+    return IB.Stock(symbol=stock.symbol,
+                    exchange='SMART',
+                    currency=stock.currency.value)
 
 
 def bondContract(bond: Bond) -> IB.Contract:
-    return IB.Bond(symbol=bond.symbol, currency=bond.currency.value)
+    return IB.Bond(symbol=bond.symbol,
+                   exchange='SMART',
+                   currency=bond.currency.value)
 
 
 def optionContract(option: Option) -> IB.Contract:
     lastTradeDate = option.expiration.strftime('%Y%m%d')
 
     return IB.Option(symbol=option.symbol,
+                     exchange='SMART',
                      currency=option.currency.value,
                      lastTradeDateOrContractMonth=lastTradeDate,
                      right=option.optionType.value)
@@ -239,13 +244,16 @@ def fopContract(option: FutureOption) -> IB.Contract:
     lastTradeDate = option.expiration.strftime('%Y%m%d')
 
     return IB.FuturesOption(symbol=option.symbol,
+                            exchange='SMART',
                             currency=option.currency.value,
                             lastTradeDateOrContractMonth=lastTradeDate,
                             right=option.optionType.value)
 
 
 def futuresContract(future: Future) -> IB.Contract:
-    return IB.Future(symbol=future.symbol, currency=future.currency.value)
+    return IB.Future(symbol=future.symbol,
+                     exchange='SMART',
+                     currency=future.currency.value)
 
 
 def forexContract(forex: Forex) -> IB.Contract:

--- a/ibkr.py
+++ b/ibkr.py
@@ -245,7 +245,7 @@ def fopContract(option: FutureOption) -> IB.Contract:
 
 
 def futuresContract(future: Future) -> IB.Contract:
-    return IB.Future(symbol=future.symbol, currency=option.currency.value)
+    return IB.Future(symbol=future.symbol, currency=future.currency.value)
 
 
 def forexContract(forex: Forex) -> IB.Contract:

--- a/model.py
+++ b/model.py
@@ -51,7 +51,8 @@ class Cash:
         return d.quantize(cls.quantization, rounding=ROUND_HALF_EVEN)
 
     def __init__(self, currency: Currency, quantity: Decimal):
-        assert quantity.is_finite()
+        assert quantity.is_finite(
+        ), 'Cash quantity {} is not a finite number'.format(quantity)
 
         self._currency = currency
         self._quantity = self.quantize(quantity)
@@ -285,13 +286,21 @@ class Forex(Instrument):
 
 
 class Quote:
-    def __init__(self, bid: Cash, ask: Cash, last: Cash):
-        assert bid.currency == ask.currency, 'Currencies in a quote should match between bid {} and ask {}'.format(
-            bid, ask)
-        assert bid.currency == last.currency, 'Currencies in a quote should match between bid {} and last {}'.format(
-            bid, last)
-        assert ask >= bid, 'Expected ask {} to be at least bid {}'.format(
-            ask, bid)
+    def __init__(self, bid: Optional[Cash], ask: Optional[Cash],
+                 last: Optional[Cash]):
+        if bid and ask:
+            assert bid.currency == ask.currency, 'Currencies in a quote should match between bid {} and ask {}'.format(
+                bid, ask)
+            assert ask >= bid, 'Expected ask {} to be at least bid {}'.format(
+                ask, bid)
+
+        if bid and last:
+            assert bid.currency == last.currency, 'Currencies in a quote should match between bid {} and last {}'.format(
+                bid, last)
+
+        if ask and last:
+            assert ask.currency == last.currency, 'Currencies in a quote should match between ask {} and last {}'.format(
+                ask, last)
 
         self._bid = bid
         self._ask = ask
@@ -299,15 +308,15 @@ class Quote:
         super().__init__()
 
     @property
-    def bid(self) -> Cash:
+    def bid(self) -> Optional[Cash]:
         return self._bid
 
     @property
-    def ask(self) -> Cash:
+    def ask(self) -> Optional[Cash]:
         return self._ask
 
     @property
-    def last(self) -> Cash:
+    def last(self) -> Optional[Cash]:
         return self._last
 
     def __eq__(self, other: Any) -> bool:

--- a/model.py
+++ b/model.py
@@ -323,6 +323,11 @@ class Future(Instrument):
     def multiplier(self) -> Decimal:
         return self._multiplier
 
+    def __repr__(self) -> str:
+        return '{}(symbol={}, currency={}, multiplier={})'.format(
+            repr(type(self)), repr(self.symbol), repr(self.currency),
+            repr(self.multiplier))
+
 
 class Forex(Instrument):
     def __init__(self, baseCurrency: Currency, quoteCurrency: Currency):

--- a/model.py
+++ b/model.py
@@ -472,7 +472,7 @@ class Trade:
     def proceeds(self) -> Cash:
         return self.amount - self.fees
 
-    def __eq__(self, other: 'Trade') -> bool:
+    def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Trade):
             return False
 

--- a/model.py
+++ b/model.py
@@ -305,7 +305,7 @@ class Quote:
 
 class LiveDataProvider(ABC):
     @abstractmethod
-    async def fetchQuote(self, instrument: Instrument) -> Quote:
+    def fetchQuote(self, instrument: Instrument) -> Quote:
         pass
 
 

--- a/model.py
+++ b/model.py
@@ -130,6 +130,9 @@ class Cash:
             self, other)
         return self.quantity >= other.quantity
 
+    def __hash__(self) -> int:
+        return hash((self.currency, self.quantity))
+
 
 class Instrument(ABC):
     @abstractmethod
@@ -155,6 +158,9 @@ class Instrument(ABC):
 
         return bool(self.symbol == other.symbol
                     and self.currency == other.currency)
+
+    def __hash__(self) -> int:
+        return hash((self.currency, self.symbol))
 
     def __lt__(self, other: 'Instrument') -> bool:
         return self.symbol < other.symbol
@@ -325,6 +331,9 @@ class Quote:
 
         return self.bid == other.bid and self.ask == other.ask and self.last == other.last
 
+    def __hash__(self) -> int:
+        return hash((self.bid, self.ask, self.last))
+
 
 class LiveDataProvider(ABC):
     @abstractmethod
@@ -366,6 +375,9 @@ class Position:
             return False
 
         return self.instrument == other.instrument and self.quantity == other.quantity and self.averagePrice == other.averagePrice
+
+    def __hash__(self) -> int:
+        return hash((self.instrument, self.quantity, self.averagePrice))
 
     @property
     def instrument(self) -> Instrument:
@@ -459,6 +471,20 @@ class Trade:
     @property
     def proceeds(self) -> Cash:
         return self.amount - self.fees
+
+    def __eq__(self, other: 'Trade') -> bool:
+        if not isinstance(other, Trade):
+            return False
+
+        return bool(self.date == other.date
+                    and self.instrument == other.instrument
+                    and self.quantity == other.quantity
+                    and self.amount == other.amount and self.fees == other.fees
+                    and self.flags == other.flags)
+
+    def __hash__(self) -> int:
+        return hash((self.date, self.instrument, self.quantity, self.amount,
+                     self.fees, self.flags))
 
     def __repr__(self) -> str:
         return 'Trade(date={}, instrument={}, quantity={}, amount={}, fees={}, flags={})'.format(

--- a/model.py
+++ b/model.py
@@ -404,6 +404,10 @@ class Quote:
     def __hash__(self) -> int:
         return hash((self.bid, self.ask, self.last, self.close))
 
+    def __repr__(self) -> str:
+        return 'Quote(bid={}, ask={}, last={}, close={})'.format(
+            repr(self.bid), repr(self.ask), repr(self.last), repr(self.close))
+
 
 class LiveDataProvider(ABC):
     @abstractmethod

--- a/model.py
+++ b/model.py
@@ -288,8 +288,26 @@ class Future(Instrument):
 
 
 class Forex(Instrument):
-    def __init__(self, symbol: str, currency: Currency):
-        super().__init__(symbol, currency)
+    def __init__(self, baseCurrency: Currency, quoteCurrency: Currency):
+        assert baseCurrency != quoteCurrency, 'Forex pair must be composed of different currencies, got {} and {}'.format(
+            repr(baseCurrency), repr(quoteCurrency))
+        self._baseCurrency = baseCurrency
+
+        symbol = '{}{}'.format(baseCurrency.name, quoteCurrency.name)
+        super().__init__(symbol, quoteCurrency)
+
+    @property
+    def quoteCurrency(self) -> Currency:
+        return self.currency
+
+    @property
+    def baseCurrency(self) -> Currency:
+        return self._baseCurrency
+
+    def __repr__(self) -> str:
+        return '{}(baseCurrency={}, quoteCurrency={})'.format(
+            repr(type(self)), repr(self.baseCurrency),
+            repr(self.quoteCurrency))
 
 
 class Quote:

--- a/model.py
+++ b/model.py
@@ -249,8 +249,12 @@ class Forex(Instrument):
 
 class Quote:
     def __init__(self, bid: Cash, ask: Cash, last: Cash):
-        assert bid.currency == ask.currency
-        assert bid.currency == last.currency
+        assert bid.currency == ask.currency, 'Currencies in a quote should match between bid {} and ask {}'.format(
+            bid, ask)
+        assert bid.currency == last.currency, 'Currencies in a quote should match between bid {} and last {}'.format(
+            bid, last)
+        assert ask >= bid, 'Expected ask {} to be at least bid {}'.format(
+            ask, bid)
 
         self._bid = bid
         self._ask = ask

--- a/model.py
+++ b/model.py
@@ -153,7 +153,8 @@ class Instrument(ABC):
         return self._currency
 
     def __eq__(self, other: Any) -> bool:
-        if not isinstance(other, Instrument):
+        # Strict typechecking, because we want different types of Instrument to be inequal.
+        if type(self) != type(other):
             return False
 
         return bool(self.symbol == other.symbol

--- a/model.py
+++ b/model.py
@@ -423,7 +423,8 @@ class Position:
             repr(self.instrument), repr(self.quantity), repr(self.costBasis))
 
     def __str__(self) -> str:
-        return '{:21} {:>14,g} @ {}'.format(self.instrument, self.quantity,
+        return '{:21} {:>14,f} @ {}'.format(self.instrument,
+                                            self.quantity.normalize(),
                                             self.averagePrice)
 
 

--- a/model.py
+++ b/model.py
@@ -132,7 +132,7 @@ class Instrument(ABC):
         if not isinstance(other, Instrument):
             return False
 
-        return self.symbol == other.symbol
+        return bool(self.symbol == other.symbol)
 
     def __lt__(self, other: 'Instrument') -> bool:
         return self.symbol < other.symbol

--- a/model.py
+++ b/model.py
@@ -1,4 +1,4 @@
-from abc import ABC
+from abc import ABC, abstractmethod
 from datetime import date, datetime
 from decimal import Decimal, ROUND_HALF_EVEN
 from enum import Enum, Flag, auto, unique
@@ -117,6 +117,7 @@ class Cash:
 
 @total_ordering
 class Instrument(ABC):
+    @abstractmethod
     def __init__(self, symbol: str):
         assert symbol, 'Expected non-empty symbol for instrument'
 
@@ -148,7 +149,8 @@ class Instrument(ABC):
 
 # Also used for ETFs.
 class Stock(Instrument):
-    pass
+    def __init__(self, symbol: str):
+        super().__init__(symbol)
 
 
 class Bond(Instrument):
@@ -236,11 +238,13 @@ class FutureOption(Option):
 
 
 class Future(Instrument):
-    pass
+    def __init__(self, symbol: str):
+        super().__init__(symbol)
 
 
 class Forex(Instrument):
-    pass
+    def __init__(self, symbol: str):
+        super().__init__(symbol)
 
 
 class Position:

--- a/model.py
+++ b/model.py
@@ -276,6 +276,12 @@ class Quote:
         return self.bid == other.bid and self.ask == other.ask and self.last == other.last
 
 
+class LiveDataProvider(ABC):
+    @abstractmethod
+    async def fetchQuote(self, instrument: Instrument) -> Quote:
+        pass
+
+
 class Position:
     quantityQuantization = Decimal('0.0001')
 

--- a/model.py
+++ b/model.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 from datetime import date, datetime
 from decimal import Decimal, ROUND_HALF_EVEN
 from enum import Enum, Flag, auto, unique
-from functools import total_ordering
 from typing import Any, Dict, NamedTuple, Optional, TypeVar, Union
 
 import re
@@ -44,7 +43,6 @@ class Currency(Enum):
 T = TypeVar('T', Decimal, int)
 
 
-@total_ordering
 class Cash:
     quantization = Decimal('0.0001')
 
@@ -112,10 +110,26 @@ class Cash:
         return self.currency == other.currency and self.quantity == other.quantity
 
     def __lt__(self, other: 'Cash') -> bool:
+        assert self.currency == other.currency, 'Currency of {} must match {} for comparison'.format(
+            self, other)
         return self.quantity < other.quantity
 
+    def __le__(self, other: 'Cash') -> bool:
+        assert self.currency == other.currency, 'Currency of {} must match {} for comparison'.format(
+            self, other)
+        return self.quantity <= other.quantity
 
-@total_ordering
+    def __gt__(self, other: 'Cash') -> bool:
+        assert self.currency == other.currency, 'Currency of {} must match {} for comparison'.format(
+            self, other)
+        return self.quantity > other.quantity
+
+    def __ge__(self, other: 'Cash') -> bool:
+        assert self.currency == other.currency, 'Currency of {} must match {} for comparison'.format(
+            self, other)
+        return self.quantity >= other.quantity
+
+
 class Instrument(ABC):
     @abstractmethod
     def __init__(self, symbol: str):
@@ -136,6 +150,15 @@ class Instrument(ABC):
 
     def __lt__(self, other: 'Instrument') -> bool:
         return self.symbol < other.symbol
+
+    def __le__(self, other: 'Instrument') -> bool:
+        return self.symbol <= other.symbol
+
+    def __gt__(self, other: 'Instrument') -> bool:
+        return self.symbol > other.symbol
+
+    def __ge__(self, other: 'Instrument') -> bool:
+        return self.symbol >= other.symbol
 
     def __format__(self, spec: str) -> str:
         return format(self.symbol, spec)

--- a/model.py
+++ b/model.py
@@ -535,6 +535,13 @@ class Trade:
         return self._fees
 
     @property
+    def price(self) -> Cash:
+        if self.quantity >= 0:
+            return -self.amount / self.instrument.multiplier
+        else:
+            return self.amount / self.instrument.multiplier
+
+    @property
     def flags(self) -> TradeFlags:
         return self._flags
 

--- a/model.py
+++ b/model.py
@@ -462,7 +462,7 @@ class Position:
             assert self.costBasis == 0
             return self.costBasis
 
-        return self.costBasis / self.quantity
+        return self.costBasis / self.quantity / self.instrument.multiplier
 
     @property
     def costBasis(self) -> Cash:

--- a/model.py
+++ b/model.py
@@ -247,6 +247,35 @@ class Forex(Instrument):
         super().__init__(symbol)
 
 
+class Quote:
+    def __init__(self, bid: Cash, ask: Cash, last: Cash):
+        assert bid.currency == ask.currency
+        assert bid.currency == last.currency
+
+        self._bid = bid
+        self._ask = ask
+        self._last = last
+        super().__init__()
+
+    @property
+    def bid(self) -> Cash:
+        return self._bid
+
+    @property
+    def ask(self) -> Cash:
+        return self._ask
+
+    @property
+    def last(self) -> Cash:
+        return self._last
+
+    def __eq__(self, other: Any) -> bool:
+        if not isinstance(other, Quote):
+            return False
+
+        return self.bid == other.bid and self.ask == other.ask and self.last == other.last
+
+
 class Position:
     quantityQuantization = Decimal('0.0001')
 

--- a/model.py
+++ b/model.py
@@ -103,6 +103,9 @@ class Cash:
     def __neg__(self) -> 'Cash':
         return Cash(currency=self.currency, quantity=-self.quantity)
 
+    def __abs__(self) -> 'Cash':
+        return Cash(currency=self.currency, quantity=abs(self.quantity))
+
     def __eq__(self, other: Any) -> bool:
         if not isinstance(other, Cash):
             # Make mypy happy

--- a/model.py
+++ b/model.py
@@ -370,6 +370,8 @@ class Position:
 
     def __init__(self, instrument: Instrument, quantity: Decimal,
                  costBasis: Cash):
+        assert instrument.currency == costBasis.currency, 'Cost basis {} should be in same currency as instrument {}'.format(
+            costBasis, instrument)
         assert quantity.is_finite()
         quantity = self.quantizeQuantity(quantity)
 

--- a/schwab.py
+++ b/schwab.py
@@ -30,6 +30,7 @@ def parseOption(symbol: str) -> Option:
         optionType = OptionType.CALL
 
     return Option(underlying=match['underlying'],
+                  currency=Currency.USD,
                   expiration=date(int(match['year']), int(match['month']),
                                   int(match['day'])),
                   optionType=optionType,
@@ -67,11 +68,11 @@ def parseSchwabPosition(p: SchwabPosition) -> Optional[Position]:
 
     instrument: Instrument
     if re.match(r'Equity|ETFs', p.securityType):
-        instrument = Stock(p.symbol)
+        instrument = Stock(p.symbol, currency=Currency.USD)
     elif re.match(r'Option', p.securityType):
         instrument = parseOption(p.symbol)
     elif re.match(r'Fixed Income', p.securityType):
-        instrument = Bond(p.symbol)
+        instrument = Bond(p.symbol, currency=Currency.USD)
     else:
         raise ValueError('Unrecognized security type: {}'.format(
             p.securityType))
@@ -113,9 +114,9 @@ def guessInstrumentFromSymbol(symbol: str) -> Instrument:
     if re.search(r'\s(C|P)$', symbol):
         return parseOption(symbol)
     elif Bond.validBondSymbol(symbol):
-        return Bond(symbol)
+        return Bond(symbol, currency=Currency.USD)
     else:
-        return Stock(symbol)
+        return Stock(symbol, currency=Currency.USD)
 
 
 def forceParseSchwabTransaction(t: SchwabTransaction,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,7 @@
 from decimal import Decimal
-from hypothesis.strategies import builds, dates, datetimes, decimals, from_regex, from_type, just, integers, one_of, register_type_strategy, sampled_from, text
+from hypothesis.strategies import builds, dates, datetimes, decimals, from_regex, from_type, just, integers, none, one_of, register_type_strategy, sampled_from, text, SearchStrategy
 from model import Cash, Currency, Instrument, Stock, Bond, Option, OptionType, FutureOption, Future, Forex, Position, Trade, TradeFlags, Quote
-from typing import List
+from typing import List, Optional, TypeVar
 
 decimalCashAmounts = decimals(allow_nan=False,
                               allow_infinity=False,
@@ -110,6 +110,11 @@ register_type_strategy(
         last=builds(
             Cash, currency=just(bid.currency), quantity=decimalCashAmounts))))
 
+
+T = TypeVar('T')
+
+def optionals(inner: SearchStrategy[T]) -> SearchStrategy[Optional[T]]:
+    return one_of(inner, none())
 
 def cashUSD(amount: Decimal) -> Cash:
     return Cash(currency=Currency.USD, quantity=amount)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -111,6 +111,8 @@ register_type_strategy(
                    quantity=decimalCashAmounts.map(lambda c: bid.quantity +
                                                    abs(c))),
         last=builds(
+            Cash, currency=just(bid.currency), quantity=decimalCashAmounts),
+        close=builds(
             Cash, currency=just(bid.currency), quantity=decimalCashAmounts))))
 
 T = TypeVar('T')

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,15 @@
+from datetime import date, datetime
 from decimal import Decimal
 from hypothesis.strategies import builds, dates, datetimes, decimals, from_regex, from_type, just, lists, integers, none, one_of, register_type_strategy, sampled_from, text, SearchStrategy
 from model import Cash, Currency, Instrument, Stock, Bond, Option, OptionType, FutureOption, Future, Forex, Position, Trade, TradeFlags, Quote
 from typing import List, Optional, TypeVar
+
+T = TypeVar('T')
+
+
+def optionals(inner: SearchStrategy[T]) -> SearchStrategy[Optional[T]]:
+    return one_of(inner, none())
+
 
 decimalCashAmounts = decimals(allow_nan=False,
                               allow_infinity=False,
@@ -22,69 +30,154 @@ decimalMultipliers = decimals(allow_nan=False,
                               max_value=Decimal('10000')).map(
                                   Instrument.quantizeMultiplier)
 
-register_type_strategy(
-    Cash,
-    builds(Cash, currency=from_type(Currency), quantity=decimalCashAmounts))
 
-register_type_strategy(
-    Bond,
-    builds(Bond,
-           symbol=from_regex(Bond.regexCUSIP),
-           currency=from_type(Currency)))
-register_type_strategy(
-    Stock, builds(Stock, symbol=text(min_size=1),
-                  currency=from_type(Currency)))
-register_type_strategy(
-    Option,
-    builds(Option,
-           underlying=text(min_size=1),
-           currency=from_type(Currency),
-           optionType=from_type(OptionType),
-           expiration=dates(),
-           strike=decimals(allow_nan=False,
-                           allow_infinity=False,
-                           min_value=Decimal('1'),
-                           max_value=Decimal('100000')),
-           multiplier=decimalMultipliers))
-register_type_strategy(
-    FutureOption,
-    builds(FutureOption,
-           symbol=text(min_size=1),
-           underlying=text(min_size=1),
-           currency=from_type(Currency),
-           optionType=from_type(OptionType),
-           expiration=dates(),
-           strike=decimals(allow_nan=False,
-                           allow_infinity=False,
-                           min_value=Decimal('1'),
-                           max_value=Decimal('100000')),
-           multiplier=decimalMultipliers))
-register_type_strategy(
-    Future,
-    builds(Future,
-           symbol=text(min_size=1),
-           currency=from_type(Currency),
-           multiplier=decimalMultipliers))
+def cash(currency: SearchStrategy[Currency] = from_type(Currency),
+         quantity: SearchStrategy[Decimal] = decimalCashAmounts
+         ) -> SearchStrategy[Cash]:
+    return builds(Cash, currency=currency, quantity=quantity)
+
+
+def bonds(symbol: SearchStrategy[str] = from_regex(Bond.regexCUSIP),
+          currency: SearchStrategy[Currency] = from_type(Currency)
+          ) -> SearchStrategy[Bond]:
+    return builds(Bond, symbol=symbol, currency=currency)
+
+
+def stocks(symbol: SearchStrategy[str] = text(min_size=1),
+           currency: SearchStrategy[Currency] = from_type(Currency)
+           ) -> SearchStrategy[Stock]:
+    return builds(Stock, symbol=symbol, currency=currency)
+
+
+def options(underlying: SearchStrategy[str] = text(min_size=1),
+            currency: SearchStrategy[Currency] = from_type(Currency),
+            optionType: SearchStrategy[OptionType] = from_type(OptionType),
+            expiration: SearchStrategy[date] = dates(),
+            strike: SearchStrategy[Decimal] = decimals(
+                allow_nan=False,
+                allow_infinity=False,
+                min_value=Decimal('1'),
+                max_value=Decimal('100000')),
+            multiplier: SearchStrategy[Decimal] = decimalMultipliers
+            ) -> SearchStrategy[Option]:
+    return builds(Option,
+                  underlying=underlying,
+                  currency=currency,
+                  optionType=optionType,
+                  expiration=expiration,
+                  strike=strike,
+                  multiplier=multiplier)
+
+
+def futuresOptions(
+        symbol: SearchStrategy[str] = text(min_size=1),
+        underlying: SearchStrategy[str] = text(min_size=1),
+        currency: SearchStrategy[Currency] = from_type(Currency),
+        optionType: SearchStrategy[OptionType] = from_type(OptionType),
+        expiration: SearchStrategy[date] = dates(),
+        strike: SearchStrategy[Decimal] = decimals(
+            allow_nan=False,
+            allow_infinity=False,
+            min_value=Decimal('1'),
+            max_value=Decimal('100000')),
+        multiplier: SearchStrategy[Decimal] = decimalMultipliers
+) -> SearchStrategy[FutureOption]:
+    return builds(FutureOption,
+                  symbol=symbol,
+                  underlying=underlying,
+                  currency=currency,
+                  optionType=optionType,
+                  expiration=expiration,
+                  strike=strike,
+                  multiplier=multiplier)
+
+
+def futures(symbol: SearchStrategy[str] = text(min_size=1),
+            currency: SearchStrategy[Currency] = from_type(Currency),
+            multiplier: SearchStrategy[Decimal] = decimalMultipliers
+            ) -> SearchStrategy[Future]:
+    return builds(Future,
+                  symbol=symbol,
+                  currency=currency,
+                  multiplier=multiplier)
+
+
+def forex(baseCurrency: SearchStrategy[Currency] = from_type(Currency),
+          quoteCurrency: SearchStrategy[Currency] = from_type(Currency)
+          ) -> SearchStrategy[Forex]:
+    return builds(Forex,
+                  baseCurrency=baseCurrency,
+                  quoteCurrency=quoteCurrency)
+
+
+def instruments(currency: SearchStrategy[Currency] = from_type(Currency)
+                ) -> SearchStrategy[Instrument]:
+    return one_of(
+        bonds(currency=currency), stocks(currency=currency),
+        options(currency=currency), futuresOptions(currency=currency),
+        futures(currency=currency),
+        currency.flatmap(lambda cur: forex(baseCurrency=from_type(Currency).
+                                           filter(lambda cur2: cur2 != cur),
+                                           quoteCurrency=just(cur))))
+
+
+def positions(instrument: SearchStrategy[Instrument] = instruments(),
+              quantity: SearchStrategy[Decimal] = decimalPositionQuantities,
+              costBasis: SearchStrategy[Cash] = cash()
+              ) -> SearchStrategy[Position]:
+    return builds(Position,
+                  instrument=instrument,
+                  quantity=quantity,
+                  costBasis=costBasis)
+
+
+def trades(date: SearchStrategy[datetime] = datetimes(),
+           instrument: SearchStrategy[Instrument] = instruments(),
+           quantity: SearchStrategy[Decimal] = decimalPositionQuantities,
+           amount: SearchStrategy[Cash] = cash(),
+           fees: SearchStrategy[Cash] = cash(
+               quantity=decimals(allow_nan=False,
+                                 allow_infinity=False,
+                                 min_value=Decimal('0'),
+                                 max_value=Decimal('10000'))),
+           flags: SearchStrategy[TradeFlags] = from_type(TradeFlags)
+           ) -> SearchStrategy[Trade]:
+    return builds(Trade,
+                  date=date,
+                  instrument=instrument,
+                  quantity=quantity,
+                  amount=amount,
+                  fees=fees,
+                  flags=flags)
+
+
+def quotes(bid: SearchStrategy[Optional[Cash]] = optionals(cash()),
+           ask: SearchStrategy[Optional[Cash]] = optionals(cash()),
+           last: SearchStrategy[Optional[Cash]] = optionals(cash()),
+           close: SearchStrategy[Optional[Cash]] = optionals(cash())
+           ) -> SearchStrategy[Quote]:
+    return builds(Quote, bid=bid, ask=ask, last=last, close=close)
+
+
+register_type_strategy(Cash, cash())
+register_type_strategy(Bond, bonds())
+register_type_strategy(Stock, stocks())
+register_type_strategy(Option, options())
+register_type_strategy(FutureOption, futuresOptions())
+register_type_strategy(Future, futures())
 
 register_type_strategy(
     Forex,
     lists(from_type(Currency), min_size=2, max_size=2,
-          unique=True).flatmap(lambda cx: builds(
-              Forex, baseCurrency=just(cx[0]), quoteCurrency=just(cx[1]))))
+          unique=True).flatmap(lambda cx: forex(baseCurrency=just(cx[0]),
+                                                quoteCurrency=just(cx[1]))))
 
-register_type_strategy(
-    Instrument,
-    one_of(from_type(Bond), from_type(Stock), from_type(Option),
-           from_type(FutureOption), from_type(Future), from_type(Forex)))
+register_type_strategy(Instrument, instruments())
 
 register_type_strategy(
     Position,
-    from_type(Instrument).flatmap(lambda i: builds(
-        Position,
-        instrument=just(i),
-        quantity=decimalPositionQuantities,
-        costBasis=builds(
-            Cash, quantity=decimalCashAmounts, currency=just(i.currency)))))
+    from_type(Instrument).flatmap(lambda i: positions(
+        instrument=just(i), costBasis=cash(currency=just(i.currency)))))
 
 register_type_strategy(
     TradeFlags,
@@ -97,46 +190,25 @@ register_type_strategy(
 
 register_type_strategy(
     Trade,
-    from_type(Instrument).flatmap(lambda i: builds(
-        Trade,
-        date=datetimes(),
+    from_type(Instrument).flatmap(lambda i: trades(
         instrument=just(i),
-        quantity=decimalPositionQuantities,
-        amount=builds(
-            Cash, currency=just(i.currency), quantity=decimalCashAmounts),
-        fees=builds(Cash,
-                    currency=just(i.currency),
-                    quantity=decimals(allow_nan=False,
-                                      allow_infinity=False,
-                                      min_value=Decimal('0'),
-                                      max_value=Decimal('10000'))),
-        flags=from_type(TradeFlags))))
-
-T = TypeVar('T')
-
-
-def optionals(inner: SearchStrategy[T]) -> SearchStrategy[Optional[T]]:
-    return one_of(inner, none())
-
+        amount=cash(currency=just(i.currency)),
+        fees=cash(currency=just(i.currency),
+                  quantity=decimals(allow_nan=False,
+                                    allow_infinity=False,
+                                    min_value=Decimal('0'),
+                                    max_value=Decimal('10000'))))))
 
 register_type_strategy(
     Quote,
-    from_type(Cash).flatmap(lambda bid: builds(
-        Quote,
+    from_type(Cash).flatmap(lambda bid: quotes(
         bid=optionals(just(bid)),
         ask=optionals(
-            builds(Cash,
-                   currency=just(bid.currency),
-                   quantity=decimalCashAmounts.map(lambda c: bid.quantity +
-                                                   abs(c)))),
-        last=optionals(
-            builds(Cash,
-                   currency=just(bid.currency),
-                   quantity=decimalCashAmounts)),
-        close=optionals(
-            builds(Cash,
-                   currency=just(bid.currency),
-                   quantity=decimalCashAmounts)))))
+            cash(currency=just(bid.currency),
+                 quantity=decimalCashAmounts.map(lambda c: bid.quantity + abs(
+                     c)))),
+        last=optionals(cash(currency=just(bid.currency))),
+        close=optionals(cash(currency=just(bid.currency))))))
 
 
 def cashUSD(amount: Decimal) -> Cash:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,6 +1,6 @@
 from decimal import Decimal
 from hypothesis.strategies import builds, dates, datetimes, decimals, from_regex, from_type, just, integers, one_of, register_type_strategy, sampled_from, text
-from model import Cash, Currency, Instrument, Stock, Bond, Option, OptionType, FutureOption, Future, Forex, Position, Trade, TradeFlags
+from model import Cash, Currency, Instrument, Stock, Bond, Option, OptionType, FutureOption, Future, Forex, Position, Trade, TradeFlags, Quote
 from typing import List
 
 decimalCashAmounts = decimals(allow_nan=False,
@@ -82,6 +82,14 @@ register_type_strategy(
                                       min_value=Decimal('0'),
                                       max_value=Decimal('10000'))),
         flags=from_type(TradeFlags))))
+
+register_type_strategy(
+    Quote,
+    from_type(Cash).flatmap(lambda bid: 
+    builds(Quote,
+           bid=just(bid),
+           ask=builds(Cash, currency=just(bid.currency), quantity=decimalCashAmounts.map(lambda c: bid.quantity + abs(c))),
+           last=builds(Cash, currency=just(bid.currency), quantity=decimalCashAmounts))))
 
 
 def cashUSD(amount: Decimal) -> Cash:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,5 +1,5 @@
 from decimal import Decimal
-from hypothesis.strategies import builds, dates, datetimes, decimals, from_regex, from_type, just, integers, none, one_of, register_type_strategy, sampled_from, text, SearchStrategy
+from hypothesis.strategies import builds, dates, datetimes, decimals, from_regex, from_type, just, lists, integers, none, one_of, register_type_strategy, sampled_from, text, SearchStrategy
 from model import Cash, Currency, Instrument, Stock, Bond, Option, OptionType, FutureOption, Future, Forex, Position, Trade, TradeFlags, Quote
 from typing import List, Optional, TypeVar
 
@@ -54,9 +54,12 @@ register_type_strategy(
 register_type_strategy(
     Future,
     builds(Future, symbol=text(min_size=1), currency=from_type(Currency)))
+
 register_type_strategy(
-    Forex, builds(Forex, symbol=text(min_size=1),
-                  currency=from_type(Currency)))
+    Forex,
+    lists(from_type(Currency), min_size=2, max_size=2,
+          unique=True).flatmap(lambda cx: builds(
+              Forex, baseCurrency=just(cx[0]), quoteCurrency=just(cx[1]))))
 
 register_type_strategy(
     Instrument,
@@ -110,11 +113,12 @@ register_type_strategy(
         last=builds(
             Cash, currency=just(bid.currency), quantity=decimalCashAmounts))))
 
-
 T = TypeVar('T')
+
 
 def optionals(inner: SearchStrategy[T]) -> SearchStrategy[Optional[T]]:
     return one_of(inner, none())
+
 
 def cashUSD(amount: Decimal) -> Cash:
     return Cash(currency=Currency.USD, quantity=amount)

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -112,25 +112,31 @@ register_type_strategy(
                                       max_value=Decimal('10000'))),
         flags=from_type(TradeFlags))))
 
-register_type_strategy(
-    Quote,
-    from_type(Cash).flatmap(lambda bid: builds(
-        Quote,
-        bid=just(bid),
-        ask=builds(Cash,
-                   currency=just(bid.currency),
-                   quantity=decimalCashAmounts.map(lambda c: bid.quantity +
-                                                   abs(c))),
-        last=builds(
-            Cash, currency=just(bid.currency), quantity=decimalCashAmounts),
-        close=builds(
-            Cash, currency=just(bid.currency), quantity=decimalCashAmounts))))
-
 T = TypeVar('T')
 
 
 def optionals(inner: SearchStrategy[T]) -> SearchStrategy[Optional[T]]:
     return one_of(inner, none())
+
+
+register_type_strategy(
+    Quote,
+    from_type(Cash).flatmap(lambda bid: builds(
+        Quote,
+        bid=optionals(just(bid)),
+        ask=optionals(
+            builds(Cash,
+                   currency=just(bid.currency),
+                   quantity=decimalCashAmounts.map(lambda c: bid.quantity +
+                                                   abs(c)))),
+        last=optionals(
+            builds(Cash,
+                   currency=just(bid.currency),
+                   quantity=decimalCashAmounts)),
+        close=optionals(
+            builds(Cash,
+                   currency=just(bid.currency),
+                   quantity=decimalCashAmounts)))))
 
 
 def cashUSD(amount: Decimal) -> Cash:

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -16,6 +16,12 @@ decimalPositionQuantities = decimals(
     max_value=Decimal('1000000000')).map(
         Position.quantizeQuantity).filter(lambda x: x != 0)
 
+decimalMultipliers = decimals(allow_nan=False,
+                              allow_infinity=False,
+                              min_value=Decimal('1'),
+                              max_value=Decimal('10000')).map(
+                                  Instrument.quantizeMultiplier)
+
 register_type_strategy(
     Cash,
     builds(Cash, currency=from_type(Currency), quantity=decimalCashAmounts))
@@ -38,7 +44,8 @@ register_type_strategy(
            strike=decimals(allow_nan=False,
                            allow_infinity=False,
                            min_value=Decimal('1'),
-                           max_value=Decimal('100000'))))
+                           max_value=Decimal('100000')),
+           multiplier=decimalMultipliers))
 register_type_strategy(
     FutureOption,
     builds(FutureOption,
@@ -50,10 +57,14 @@ register_type_strategy(
            strike=decimals(allow_nan=False,
                            allow_infinity=False,
                            min_value=Decimal('1'),
-                           max_value=Decimal('100000'))))
+                           max_value=Decimal('100000')),
+           multiplier=decimalMultipliers))
 register_type_strategy(
     Future,
-    builds(Future, symbol=text(min_size=1), currency=from_type(Currency)))
+    builds(Future,
+           symbol=text(min_size=1),
+           currency=from_type(Currency),
+           multiplier=decimalMultipliers))
 
 register_type_strategy(
     Forex,

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -85,11 +85,15 @@ register_type_strategy(
 
 register_type_strategy(
     Quote,
-    from_type(Cash).flatmap(lambda bid: 
-    builds(Quote,
-           bid=just(bid),
-           ask=builds(Cash, currency=just(bid.currency), quantity=decimalCashAmounts.map(lambda c: bid.quantity + abs(c))),
-           last=builds(Cash, currency=just(bid.currency), quantity=decimalCashAmounts))))
+    from_type(Cash).flatmap(lambda bid: builds(
+        Quote,
+        bid=just(bid),
+        ask=builds(Cash,
+                   currency=just(bid.currency),
+                   quantity=decimalCashAmounts.map(lambda c: bid.quantity +
+                                                   abs(c))),
+        last=builds(
+            Cash, currency=just(bid.currency), quantity=decimalCashAmounts))))
 
 
 def cashUSD(amount: Decimal) -> Cash:

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -28,7 +28,7 @@ def tradesForAmounts(draw: Any, symbol: str,
     return (Trade(
         date=draw(datetimes()),
         instrument=draw(instruments),
-        quantity=draw(helpers.decimalPositionQuantities),
+        quantity=draw(helpers.positionQuantities()),
         amount=Cash(currency=cx, quantity=x),
         fees=Cash(currency=cx, quantity=Decimal(0)),
         flags=draw(from_type(TradeFlags)),
@@ -75,7 +75,7 @@ class TestAnalysis(unittest.TestCase):
 
     # pylint: disable=no-value-for-parameter
     @given(
-        lists(helpers.decimalCashAmounts, min_size=1,
+        lists(helpers.cashAmounts(), min_size=1,
               max_size=20).flatmap(lambda ds: tradesForAmounts(
                   amounts=ds, symbol='SPY').map(lambda ts: (ds, ts))))
     def test_realizedBasisAddsUp(self,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -39,13 +39,14 @@ class TestAnalysis(unittest.TestCase):
     def test_realizedBasis(self) -> None:
         trades = [
             Trade(date=datetime.now(),
-                  instrument=Stock('SPY'),
+                  instrument=Stock('SPY', Currency.USD),
                   quantity=Decimal('5'),
                   amount=helpers.cashUSD(Decimal('-999')),
                   fees=helpers.cashUSD(Decimal('1')),
                   flags=TradeFlags.OPEN),
             Trade(date=datetime.now(),
                   instrument=Option(underlying='SPY',
+                                    currency=Currency.USD,
                                     optionType=OptionType.CALL,
                                     expiration=date.today(),
                                     strike=Decimal('123')),

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,7 +1,7 @@
 from analysis import realizedBasisForSymbol, liveValuesForPositions
 from datetime import datetime, date
 from decimal import Decimal
-from hypothesis import given, reproduce_failure
+from hypothesis import given, reproduce_failure, seed
 from hypothesis.strategies import builds, composite, dates, datetimes, decimals, from_type, iterables, just, lists, one_of, text, tuples, SearchStrategy
 from model import Cash, Currency, Instrument, Stock, Option, OptionType, Quote, Trade, TradeFlags, LiveDataProvider, Position
 from typing import Any, Dict, Iterable, List, Tuple, no_type_check
@@ -110,7 +110,7 @@ class TestAnalysis(unittest.TestCase):
         if realizedBasis:
             self.assertEqual(realizedBasis.quantity, -summed)
 
-    @given(lists(positionAndQuote(), min_size=1))
+    @given(lists(positionAndQuote(), min_size=1, max_size=3))
     def test_liveValuesForPositions(self,
                                     i: List[Tuple[Position, Quote]]) -> None:
         quotesByInstrument = {p.instrument: q for (p, q) in i}

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -19,20 +19,23 @@ class TestFidelityPositions(unittest.TestCase):
         self.assertEqual(len(self.positions), 6)
 
     def test_tBill(self) -> None:
-        self.assertEqual(self.positions[0].instrument, Bond('942792RU5'))
+        self.assertEqual(self.positions[0].instrument,
+                         Bond('942792RU5', Currency.USD))
         self.assertEqual(self.positions[0].quantity, 10000)
         self.assertEqual(self.positions[0].costBasis,
                          Cash(currency=Currency.USD, quantity=Decimal('9800')))
 
     def test_aapl(self) -> None:
-        self.assertEqual(self.positions[1].instrument, Stock('AAPL'))
+        self.assertEqual(self.positions[1].instrument,
+                         Stock('AAPL', Currency.USD))
         self.assertEqual(self.positions[1].quantity, Decimal('100'))
         self.assertEqual(
             self.positions[1].costBasis,
             Cash(currency=Currency.USD, quantity=Decimal('14000')))
 
     def test_robo(self) -> None:
-        self.assertEqual(self.positions[2].instrument, Stock('ROBO'))
+        self.assertEqual(self.positions[2].instrument,
+                         Stock('ROBO', Currency.USD))
         self.assertEqual(self.positions[2].quantity, Decimal('10'))
         self.assertEqual(self.positions[2].costBasis,
                          Cash(currency=Currency.USD, quantity=Decimal('300')))
@@ -41,6 +44,7 @@ class TestFidelityPositions(unittest.TestCase):
         self.assertEqual(
             self.positions[3].instrument,
             Option(underlying='SPY',
+                   currency=Currency.USD,
                    optionType=OptionType.CALL,
                    expiration=date(2019, 1, 25),
                    strike=Decimal('265')))
@@ -53,6 +57,7 @@ class TestFidelityPositions(unittest.TestCase):
         self.assertEqual(
             self.positions[4].instrument,
             Option(underlying='SPY',
+                   currency=Currency.USD,
                    optionType=OptionType.PUT,
                    expiration=date(2019, 3, 22),
                    strike=Decimal('189')))
@@ -62,7 +67,8 @@ class TestFidelityPositions(unittest.TestCase):
             Cash(currency=Currency.USD, quantity=Decimal('5432.78')))
 
     def test_v(self) -> None:
-        self.assertEqual(self.positions[5].instrument, Stock('V'))
+        self.assertEqual(self.positions[5].instrument,
+                         Stock('V', Currency.USD))
         self.assertEqual(self.positions[5].quantity, Decimal('20'))
         self.assertEqual(self.positions[5].costBasis,
                          Cash(currency=Currency.USD, quantity=Decimal('2600')))
@@ -85,7 +91,7 @@ class TestFidelityTransactions(unittest.TestCase):
     def test_buySecurity(self) -> None:
         ts = self.tradesByDate[date(2017, 9, 23)]
         self.assertEqual(len(ts), 1)
-        self.assertEqual(ts[0].instrument, Stock('USFD'))
+        self.assertEqual(ts[0].instrument, Stock('USFD', Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('178'))
         self.assertEqual(
             ts[0].amount,
@@ -97,7 +103,7 @@ class TestFidelityTransactions(unittest.TestCase):
     def test_reinvestShares(self) -> None:
         ts = self.tradesByDate[date(2017, 11, 9)]
         self.assertEqual(len(ts), 3)
-        self.assertEqual(ts[1].instrument, Stock('ROBO'))
+        self.assertEqual(ts[1].instrument, Stock('ROBO', Currency.USD))
         self.assertEqual(ts[1].quantity, Decimal('0.234'))
         self.assertEqual(
             ts[1].amount, Cash(currency=Currency.USD,
@@ -116,6 +122,7 @@ class TestFidelityTransactions(unittest.TestCase):
         self.assertEqual(
             ts[0].instrument,
             Option(underlying='SPY',
+                   currency=Currency.USD,
                    optionType=OptionType.PUT,
                    expiration=date(2018, 3, 22),
                    strike=Decimal('198')))
@@ -133,6 +140,7 @@ class TestFidelityTransactions(unittest.TestCase):
         self.assertEqual(
             ts[2].instrument,
             Option(underlying='SPY',
+                   currency=Currency.USD,
                    optionType=OptionType.CALL,
                    expiration=date(2018, 1, 25),
                    strike=Decimal('260')))

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -153,7 +153,11 @@ class TestIBKRTrades(unittest.TestCase):
         ts = self.tradesBySymbol[symbol]
         self.assertEqual(len(ts), 1)
         self.assertEqual(ts[0].date.date(), date(2019, 2, 26))
-        self.assertEqual(ts[0].instrument, Future(symbol, Currency.USD))
+        self.assertEqual(
+            ts[0].instrument,
+            Future(symbol=symbol,
+                   currency=Currency.USD,
+                   multiplier=Decimal(50)))
         self.assertEqual(ts[0].quantity, Decimal('1'))
         self.assertEqual(ts[0].amount, helpers.cashUSD(Decimal('-139687.5')))
         self.assertEqual(ts[0].fees, helpers.cashUSD(Decimal('2.05')))
@@ -171,7 +175,8 @@ class TestIBKRTrades(unittest.TestCase):
                          underlying='GBUJ9',
                          optionType=OptionType.CALL,
                          expiration=date(2019, 4, 5),
-                         strike=Decimal('1.335')))
+                         strike=Decimal('1.335'),
+                         multiplier=Decimal(62500)))
         self.assertEqual(ts[0].quantity, Decimal('1'))
         self.assertEqual(ts[0].amount, helpers.cashUSD(Decimal('-918.75')))
         self.assertEqual(ts[0].fees, helpers.cashUSD(Decimal('2.47')))

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -107,11 +107,13 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(ts[0].flags, TradeFlags.CLOSE)
 
     def test_buyForex(self) -> None:
-        symbol = 'GBP.USD'
+        symbol = 'GBPUSD'
         ts = self.tradesBySymbol[symbol]
         self.assertEqual(len(ts), 2)
         self.assertEqual(ts[0].date.date(), date(2019, 2, 12))
-        self.assertEqual(ts[0].instrument, Forex(symbol, Currency.USD))
+        self.assertEqual(
+            ts[0].instrument,
+            Forex(baseCurrency=Currency.GBP, quoteCurrency=Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('3060'))
         self.assertEqual(
             ts[0].amount,
@@ -129,11 +131,13 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(ts[1].flags, TradeFlags.OPEN)
 
     def test_buyForexCross(self) -> None:
-        symbol = 'GBP.AUD'
+        symbol = 'GBPAUD'
         ts = self.tradesBySymbol[symbol]
         self.assertEqual(len(ts), 1)
         self.assertEqual(ts[0].date.date(), date(2019, 3, 25))
-        self.assertEqual(ts[0].instrument, Forex(symbol, Currency.AUD))
+        self.assertEqual(
+            ts[0].instrument,
+            Forex(baseCurrency=Currency.GBP, quoteCurrency=Currency.AUD))
         self.assertEqual(ts[0].quantity, Decimal('5000'))
         self.assertEqual(
             ts[0].amount,

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -27,7 +27,7 @@ class TestIBKRTrades(unittest.TestCase):
         ts = self.tradesBySymbol[symbol]
         self.assertEqual(len(ts), 1)
         self.assertEqual(ts[0].date.date(), date(2019, 2, 12))
-        self.assertEqual(ts[0].instrument, Stock(symbol))
+        self.assertEqual(ts[0].instrument, Stock(symbol, Currency.GBP))
         self.assertEqual(ts[0].quantity, Decimal('100'))
         self.assertEqual(
             ts[0].amount, Cash(currency=Currency.GBP,
@@ -41,7 +41,7 @@ class TestIBKRTrades(unittest.TestCase):
         ts = self.tradesBySymbol[symbol]
         self.assertEqual(len(ts), 1)
         self.assertEqual(ts[0].date.date(), date(2019, 2, 12))
-        self.assertEqual(ts[0].instrument, Stock(symbol))
+        self.assertEqual(ts[0].instrument, Stock(symbol, Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('17'))
         self.assertEqual(
             ts[0].amount, Cash(currency=Currency.USD,
@@ -56,7 +56,8 @@ class TestIBKRTrades(unittest.TestCase):
         ts = self.tradesBySymbol[symbol]
         self.assertEqual(len(ts), 1)
         self.assertEqual(ts[0].date.date(), date(2019, 3, 19))
-        self.assertEqual(ts[0].instrument, Bond(symbol, validateSymbol=False))
+        self.assertEqual(ts[0].instrument,
+                         Bond(symbol, Currency.USD, validateSymbol=False))
         self.assertEqual(ts[0].quantity, Decimal('2000'))
         self.assertEqual(
             ts[0].amount,
@@ -73,6 +74,7 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(
             ts[0].instrument,
             Option(underlying='HYG',
+                   currency=Currency.USD,
                    optionType=OptionType.PUT,
                    expiration=date(2019, 11, 15),
                    strike=Decimal('87')))
@@ -92,6 +94,7 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(
             ts[0].instrument,
             Option(underlying='MTCH',
+                   currency=Currency.USD,
                    optionType=OptionType.PUT,
                    expiration=date(2019, 2, 15),
                    strike=Decimal('45')))
@@ -108,7 +111,7 @@ class TestIBKRTrades(unittest.TestCase):
         ts = self.tradesBySymbol[symbol]
         self.assertEqual(len(ts), 2)
         self.assertEqual(ts[0].date.date(), date(2019, 2, 12))
-        self.assertEqual(ts[0].instrument, Forex(symbol))
+        self.assertEqual(ts[0].instrument, Forex(symbol, Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('3060'))
         self.assertEqual(
             ts[0].amount,
@@ -116,7 +119,7 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(ts[0].fees,
                          Cash(currency=Currency.USD, quantity=Decimal('2')))
         self.assertEqual(ts[0].flags, TradeFlags.OPEN)
-        self.assertEqual(ts[1].instrument, Forex(symbol))
+        self.assertEqual(ts[1].instrument, Forex(symbol, Currency.USD))
         self.assertEqual(ts[1].quantity, Decimal('50'))
         self.assertEqual(
             ts[1].amount,
@@ -130,7 +133,7 @@ class TestIBKRTrades(unittest.TestCase):
         ts = self.tradesBySymbol[symbol]
         self.assertEqual(len(ts), 1)
         self.assertEqual(ts[0].date.date(), date(2019, 3, 25))
-        self.assertEqual(ts[0].instrument, Forex(symbol))
+        self.assertEqual(ts[0].instrument, Forex(symbol, Currency.AUD))
         self.assertEqual(ts[0].quantity, Decimal('5000'))
         self.assertEqual(
             ts[0].amount,
@@ -144,7 +147,7 @@ class TestIBKRTrades(unittest.TestCase):
         ts = self.tradesBySymbol[symbol]
         self.assertEqual(len(ts), 1)
         self.assertEqual(ts[0].date.date(), date(2019, 2, 26))
-        self.assertEqual(ts[0].instrument, Future(symbol))
+        self.assertEqual(ts[0].instrument, Future(symbol, Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('1'))
         self.assertEqual(ts[0].amount, helpers.cashUSD(Decimal('-139687.5')))
         self.assertEqual(ts[0].fees, helpers.cashUSD(Decimal('2.05')))
@@ -158,6 +161,7 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(
             ts[0].instrument,
             FutureOption(symbol=symbol,
+                         currency=Currency.USD,
                          underlying='GBUJ9',
                          optionType=OptionType.CALL,
                          expiration=date(2019, 4, 5),

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -121,7 +121,9 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(ts[0].fees,
                          Cash(currency=Currency.USD, quantity=Decimal('2')))
         self.assertEqual(ts[0].flags, TradeFlags.OPEN)
-        self.assertEqual(ts[1].instrument, Forex(symbol, Currency.USD))
+        self.assertEqual(
+            ts[1].instrument,
+            Forex(baseCurrency=Currency.GBP, quoteCurrency=Currency.USD))
         self.assertEqual(ts[1].quantity, Decimal('50'))
         self.assertEqual(
             ts[1].amount,

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -84,6 +84,8 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(
             ts[0].fees, Cash(currency=Currency.USD,
                              quantity=Decimal('0.7182')))
+        self.assertEqual(ts[0].price,
+                         Cash(currency=Currency.USD, quantity=Decimal('5.65')))
         self.assertEqual(ts[0].flags, TradeFlags.OPEN)
 
     def test_sellOption(self) -> None:
@@ -104,6 +106,8 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(
             ts[0].fees,
             Cash(currency=Currency.USD, quantity=Decimal('1.320915')))
+        self.assertEqual(ts[0].price,
+                         Cash(currency=Currency.USD, quantity=Decimal('0.55')))
         self.assertEqual(ts[0].flags, TradeFlags.CLOSE)
 
     def test_buyForex(self) -> None:
@@ -161,6 +165,9 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(ts[0].quantity, Decimal('1'))
         self.assertEqual(ts[0].amount, helpers.cashUSD(Decimal('-139687.5')))
         self.assertEqual(ts[0].fees, helpers.cashUSD(Decimal('2.05')))
+        self.assertEqual(
+            ts[0].price,
+            Cash(currency=Currency.USD, quantity=Decimal('2793.75')))
         self.assertEqual(ts[0].flags, TradeFlags.OPEN)
 
     def test_buyFutureOption(self) -> None:
@@ -180,6 +187,9 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(ts[0].quantity, Decimal('1'))
         self.assertEqual(ts[0].amount, helpers.cashUSD(Decimal('-918.75')))
         self.assertEqual(ts[0].fees, helpers.cashUSD(Decimal('2.47')))
+        self.assertEqual(
+            ts[0].price, Cash(currency=Currency.USD,
+                              quantity=Decimal('0.0147')))
         self.assertEqual(ts[0].flags, TradeFlags.OPEN)
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,7 @@ from datetime import date
 from decimal import Decimal, ROUND_UP
 from hypothesis import assume, given, reproduce_failure
 from hypothesis.strategies import dates, decimals, from_type, integers, lists, one_of, sampled_from, text
-from model import Cash, Currency, Instrument, Bond, Stock, Option, OptionType, FutureOption, Future, Forex, Position, Quote
+from model import Cash, Currency, Instrument, Bond, Stock, Option, OptionType, FutureOption, Future, Forex, Position, Quote, Trade
 from typing import List, Optional, TypeVar
 
 import helpers
@@ -261,6 +261,12 @@ class TestQuote(unittest.TestCase):
         b = Quote(cashBid, cashAsk, cashLast)
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))
+
+
+class TestTrade(unittest.TestCase):
+    @given(from_type(Trade))
+    def test_tradeEqualsItself(self, t: Trade) -> None:
+        self.assertEqual(t, t)
 
 
 if __name__ == '__main__':

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -161,35 +161,37 @@ class TestPosition(unittest.TestCase):
         with self.assertRaises(AssertionError):
             a.combine(b)
 
-    @given(from_type(Instrument), from_type(Currency))
-    def test_combineIncreasesBasis(self, i: Instrument, c: Currency) -> None:
+    @given(from_type(Instrument))
+    def test_combineIncreasesBasis(self, i: Instrument) -> None:
         a = Position(instrument=i,
                      quantity=Decimal('100'),
-                     costBasis=Cash(currency=c, quantity=Decimal('10')))
+                     costBasis=Cash(currency=i.currency,
+                                    quantity=Decimal('10')))
         b = Position(instrument=i,
                      quantity=Decimal('300'),
-                     costBasis=Cash(currency=c, quantity=Decimal('20')))
+                     costBasis=Cash(currency=i.currency,
+                                    quantity=Decimal('20')))
 
         combined = a.combine(b)
         self.assertEqual(combined.instrument, i)
         self.assertEqual(combined.quantity, Decimal('400'))
         self.assertEqual(combined.costBasis,
-                         Cash(currency=c, quantity=Decimal('30')))
+                         Cash(currency=i.currency, quantity=Decimal('30')))
 
-    @given(from_type(Instrument), from_type(Currency),
-           helpers.decimalPositionQuantities, helpers.decimalCashAmounts,
-           helpers.decimalPositionQuantities, helpers.decimalCashAmounts)
-    def test_combineIsCommutative(self, i: Instrument, c: Currency,
-                                  aQty: Decimal, aPrice: Decimal,
-                                  bQty: Decimal, bPrice: Decimal) -> None:
+    @given(from_type(Instrument), helpers.decimalPositionQuantities,
+           helpers.decimalCashAmounts, helpers.decimalPositionQuantities,
+           helpers.decimalCashAmounts)
+    def test_combineIsCommutative(self, i: Instrument, aQty: Decimal,
+                                  aPrice: Decimal, bQty: Decimal,
+                                  bPrice: Decimal) -> None:
         assume(aQty != -bQty)
 
         a = Position(instrument=i,
                      quantity=aQty,
-                     costBasis=Cash(currency=c, quantity=aPrice))
+                     costBasis=Cash(currency=i.currency, quantity=aPrice))
         b = Position(instrument=i,
                      quantity=bQty,
-                     costBasis=Cash(currency=c, quantity=bPrice))
+                     costBasis=Cash(currency=i.currency, quantity=bPrice))
         self.assertEqual(a.combine(b), b.combine(a))
 
     @given(from_type(Position))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -3,7 +3,7 @@ from decimal import Decimal, ROUND_UP
 from hypothesis import assume, given, reproduce_failure
 from hypothesis.strategies import dates, decimals, from_type, integers, lists, one_of, sampled_from, text
 from model import Cash, Currency, Instrument, Bond, Stock, Option, OptionType, FutureOption, Future, Forex, Position, Quote
-from typing import List, TypeVar
+from typing import List, Optional, TypeVar
 
 import helpers
 import unittest
@@ -244,6 +244,23 @@ class TestQuote(unittest.TestCase):
     @given(from_type(Quote))
     def test_quoteEqualsItself(self, q: Quote) -> None:
         self.assertEqual(q, q)
+
+    @given(from_type(Currency), helpers.optionals(helpers.decimalCashAmounts),
+           helpers.optionals(helpers.decimalCashAmounts),
+           helpers.optionals(helpers.decimalCashAmounts))
+    def test_quoteEquality(self, currency: Currency, bid: Optional[Decimal],
+                           ask: Optional[Decimal],
+                           last: Optional[Decimal]) -> None:
+        assume((not bid) or (not ask) or (ask > bid))
+
+        cashBid = Cash(currency=currency, quantity=bid) if bid else None
+        cashAsk = Cash(currency=currency, quantity=ask) if ask else None
+        cashLast = Cash(currency=currency, quantity=last) if last else None
+
+        a = Quote(cashBid, cashAsk, cashLast)
+        b = Quote(cashBid, cashAsk, cashLast)
+        self.assertEqual(a, b)
+        self.assertEqual(hash(a), hash(b))
 
 
 if __name__ == '__main__':

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -14,8 +14,8 @@ T = TypeVar('T', Decimal, int)
 class TestCash(unittest.TestCase):
     @given(
         sampled_from(Currency),
-        helpers.decimalCashAmounts,
-        helpers.decimalCashAmounts,
+        helpers.cashAmounts(),
+        helpers.cashAmounts(),
     )
     def test_addCash(self, cur: Currency, a: Decimal, b: Decimal) -> None:
         cashA = Cash(currency=cur, quantity=a)
@@ -27,8 +27,8 @@ class TestCash(unittest.TestCase):
 
     @given(
         sampled_from(Currency),
-        helpers.decimalCashAmounts,
-        helpers.decimalCashAmounts,
+        helpers.cashAmounts(),
+        helpers.cashAmounts(),
     )
     def test_subtractCash(self, cur: Currency, a: Decimal, b: Decimal) -> None:
         cashA = Cash(currency=cur, quantity=a)
@@ -40,8 +40,8 @@ class TestCash(unittest.TestCase):
 
     @given(
         lists(sampled_from(Currency), min_size=2, max_size=2, unique=True),
-        helpers.decimalCashAmounts,
-        helpers.decimalCashAmounts,
+        helpers.cashAmounts(),
+        helpers.cashAmounts(),
     )
     def test_addIncompatibleCash(self, curs: List[Currency], a: Decimal,
                                  b: Decimal) -> None:
@@ -53,8 +53,8 @@ class TestCash(unittest.TestCase):
 
     @given(
         lists(sampled_from(Currency), min_size=2, max_size=2, unique=True),
-        helpers.decimalCashAmounts,
-        helpers.decimalCashAmounts,
+        helpers.cashAmounts(),
+        helpers.cashAmounts(),
     )
     def test_subtractIncompatibleCash(self, curs: List[Currency], a: Decimal,
                                       b: Decimal) -> None:
@@ -67,9 +67,8 @@ class TestCash(unittest.TestCase):
     @given(
         from_type(Cash),
         one_of(
-            helpers.decimalCashAmounts,
-            helpers.decimalCashAmounts.map(lambda d: int(d.to_integral_value())
-                                           )),
+            helpers.cashAmounts(),
+            helpers.cashAmounts().map(lambda d: int(d.to_integral_value()))),
     )
     def test_multiplyCash(self, cashA: Cash, b: T) -> None:
         cashC = cashA * b
@@ -78,10 +77,9 @@ class TestCash(unittest.TestCase):
 
     @given(
         from_type(Cash),
-        one_of(
-            helpers.decimalCashAmounts,
-            helpers.decimalCashAmounts.map(lambda d: int(d.to_integral_value())
-                                           )).filter(lambda x: x != 0),
+        one_of(helpers.cashAmounts(),
+               helpers.cashAmounts().map(lambda d: int(d.to_integral_value()))
+               ).filter(lambda x: x != 0),
     )
     def test_divideCash(self, cashA: Cash, b: T) -> None:
         cashC = cashA / b
@@ -94,7 +92,7 @@ class TestCash(unittest.TestCase):
 
     @given(
         sampled_from(Currency),
-        helpers.decimalCashAmounts,
+        helpers.cashAmounts(),
     )
     def test_cashEquality(self, cur: Currency, a: Decimal) -> None:
         cashA = Cash(currency=cur, quantity=a)
@@ -104,9 +102,8 @@ class TestCash(unittest.TestCase):
 
     @given(
         sampled_from(Currency),
-        helpers.decimalCashAmounts,
-        helpers.decimalCashAmounts.filter(lambda x: abs(x) >= Decimal('0.0001')
-                                          ),
+        helpers.cashAmounts(),
+        helpers.cashAmounts().filter(lambda x: abs(x) >= Decimal('0.0001')),
     )
     def test_cashInequality(self, cur: Currency, a: Decimal,
                             b: Decimal) -> None:
@@ -119,8 +116,8 @@ class TestCash(unittest.TestCase):
 
     @given(
         sampled_from(Currency),
-        helpers.decimalCashAmounts,
-        helpers.decimalCashAmounts.map(abs),
+        helpers.cashAmounts(),
+        helpers.cashAmounts().map(abs),
     )
     def test_cashComparison(self, cur: Currency, a: Decimal,
                             b: Decimal) -> None:
@@ -178,9 +175,9 @@ class TestPosition(unittest.TestCase):
         self.assertEqual(combined.costBasis,
                          Cash(currency=i.currency, quantity=Decimal('30')))
 
-    @given(from_type(Instrument), helpers.decimalPositionQuantities,
-           helpers.decimalCashAmounts, helpers.decimalPositionQuantities,
-           helpers.decimalCashAmounts)
+    @given(from_type(Instrument), helpers.positionQuantities(),
+           helpers.cashAmounts(), helpers.positionQuantities(),
+           helpers.cashAmounts())
     def test_combineIsCommutative(self, i: Instrument, aQty: Decimal,
                                   aPrice: Decimal, bQty: Decimal,
                                   bPrice: Decimal) -> None:
@@ -247,10 +244,10 @@ class TestQuote(unittest.TestCase):
     def test_quoteEqualsItself(self, q: Quote) -> None:
         self.assertEqual(q, q)
 
-    @given(from_type(Currency), helpers.optionals(helpers.decimalCashAmounts),
-           helpers.optionals(helpers.decimalCashAmounts),
-           helpers.optionals(helpers.decimalCashAmounts),
-           helpers.optionals(helpers.decimalCashAmounts))
+    @given(from_type(Currency), helpers.optionals(helpers.cashAmounts()),
+           helpers.optionals(helpers.cashAmounts()),
+           helpers.optionals(helpers.cashAmounts()),
+           helpers.optionals(helpers.cashAmounts()))
     def test_quoteEquality(self, currency: Currency, bid: Optional[Decimal],
                            ask: Optional[Decimal], last: Optional[Decimal],
                            close: Optional[Decimal]) -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -100,6 +100,7 @@ class TestCash(unittest.TestCase):
         cashA = Cash(currency=cur, quantity=a)
         cashB = Cash(currency=cur, quantity=a)
         self.assertEqual(cashA, cashB)
+        self.assertEqual(hash(cashA), hash(cashB))
 
     @given(
         sampled_from(Currency),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -249,18 +249,20 @@ class TestQuote(unittest.TestCase):
 
     @given(from_type(Currency), helpers.optionals(helpers.decimalCashAmounts),
            helpers.optionals(helpers.decimalCashAmounts),
+           helpers.optionals(helpers.decimalCashAmounts),
            helpers.optionals(helpers.decimalCashAmounts))
     def test_quoteEquality(self, currency: Currency, bid: Optional[Decimal],
-                           ask: Optional[Decimal],
-                           last: Optional[Decimal]) -> None:
+                           ask: Optional[Decimal], last: Optional[Decimal],
+                           close: Optional[Decimal]) -> None:
         assume((not bid) or (not ask) or (ask > bid))
 
         cashBid = Cash(currency=currency, quantity=bid) if bid else None
         cashAsk = Cash(currency=currency, quantity=ask) if ask else None
         cashLast = Cash(currency=currency, quantity=last) if last else None
+        cashClose = Cash(currency=currency, quantity=close) if close else None
 
-        a = Quote(cashBid, cashAsk, cashLast)
-        b = Quote(cashBid, cashAsk, cashLast)
+        a = Quote(cashBid, cashAsk, cashLast, cashClose)
+        b = Quote(cashBid, cashAsk, cashLast, cashClose)
         self.assertEqual(a, b)
         self.assertEqual(hash(a), hash(b))
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,7 @@ from datetime import date
 from decimal import Decimal, ROUND_UP
 from hypothesis import assume, given, reproduce_failure
 from hypothesis.strategies import dates, decimals, from_type, integers, lists, one_of, sampled_from, text
-from model import Cash, Currency, Instrument, Bond, Stock, Option, OptionType, FutureOption, Future, Forex, Position, Quote, Trade
+from model import Cash, Currency, Instrument, Bond, Stock, Option, OptionType, FutureOption, Future, Position, Quote, Trade
 from typing import List, Optional, TypeVar
 
 import helpers

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,7 @@ from datetime import date
 from decimal import Decimal, ROUND_UP
 from hypothesis import assume, given, reproduce_failure
 from hypothesis.strategies import dates, decimals, from_type, integers, lists, one_of, sampled_from, text
-from model import Cash, Currency, Instrument, Bond, Stock, Option, OptionType, FutureOption, Future, Forex, Position
+from model import Cash, Currency, Instrument, Bond, Stock, Option, OptionType, FutureOption, Future, Forex, Position, Quote
 from typing import List, TypeVar
 
 import helpers
@@ -219,6 +219,12 @@ class TestOption(unittest.TestCase):
         self.assertEqual(o.symbol, 'LAMR  150117C00052500')
 
     # TODO: Mini-options support
+
+
+class TestQuote(unittest.TestCase):
+    @given(from_type(Quote))
+    def test_quoteEqualsItself(self, q: Quote) -> None:
+        self.assertEqual(q, q)
 
 
 if __name__ == '__main__':

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -272,6 +272,35 @@ class TestTrade(unittest.TestCase):
     def test_tradeEqualsItself(self, t: Trade) -> None:
         self.assertEqual(t, t)
 
+    @given(from_type(Trade))
+    def test_signOfTradePrice(self, t: Trade) -> None:
+        if t.quantity >= 0:
+            if t.amount.quantity >= 0:
+                self.assertLessEqual(
+                    t.price.quantity,
+                    0,
+                    msg=
+                    'Buy transaction for profit should have a negative price')
+            else:
+                self.assertGreaterEqual(
+                    t.price.quantity,
+                    0,
+                    msg='Buy transaction for loss should have a positive price'
+                )
+        else:
+            if t.amount.quantity >= 0:
+                self.assertGreaterEqual(
+                    t.price.quantity,
+                    0,
+                    msg=
+                    'Sell transaction for profit should have a positive price')
+            else:
+                self.assertLessEqual(
+                    t.price.quantity,
+                    0,
+                    msg='Sell transaction for loss should have a negative price'
+                )
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -202,6 +202,22 @@ class TestPosition(unittest.TestCase):
         self.assertEqual(combined.costBasis, Decimal(0))
 
 
+class TestInstrument(unittest.TestCase):
+    @given(from_type(Instrument))
+    def test_instrumentEqualsItself(self, i: Instrument) -> None:
+        self.assertEqual(i, i)
+
+    @given(from_type(Instrument))
+    def test_instrumentHashStable(self, i: Instrument) -> None:
+        self.assertEqual(hash(i), hash(i))
+
+    @given(from_type(Instrument), from_type(Instrument))
+    def test_differentInstrumentTypesNotEqual(self, a: Instrument,
+                                              b: Instrument) -> None:
+        assume(type(a) != type(b))
+        self.assertNotEqual(a, b)
+
+
 class TestOption(unittest.TestCase):
     # https://en.wikipedia.org/wiki/Option_symbol#The_OCC_Option_Symbol
     def test_spxSymbol(self) -> None:

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -206,6 +206,7 @@ class TestOption(unittest.TestCase):
     # https://en.wikipedia.org/wiki/Option_symbol#The_OCC_Option_Symbol
     def test_spxSymbol(self) -> None:
         o = Option(underlying='SPX',
+                   currency=Currency.USD,
                    optionType=OptionType.PUT,
                    expiration=date(2014, 11, 22),
                    strike=Decimal('19.50'))
@@ -213,6 +214,7 @@ class TestOption(unittest.TestCase):
 
     def test_lamrSymbol(self) -> None:
         o = Option(underlying='LAMR',
+                   currency=Currency.USD,
                    optionType=OptionType.CALL,
                    expiration=date(2015, 1, 17),
                    strike=Decimal('52.50'))

--- a/tests/test_schwab.py
+++ b/tests/test_schwab.py
@@ -19,25 +19,29 @@ class TestSchwabPositions(unittest.TestCase):
         self.assertEqual(len(self.positions), 4)
 
     def test_tBill(self) -> None:
-        self.assertEqual(self.positions[0].instrument, Bond('193845XM2'))
+        self.assertEqual(self.positions[0].instrument,
+                         Bond('193845XM2', Currency.USD))
         self.assertEqual(self.positions[0].quantity, 10000)
         self.assertEqual(self.positions[0].costBasis,
                          helpers.cashUSD(Decimal('9956.80')))
 
     def test_bnd(self) -> None:
-        self.assertEqual(self.positions[1].instrument, Stock('BND'))
+        self.assertEqual(self.positions[1].instrument,
+                         Stock('BND', Currency.USD))
         self.assertEqual(self.positions[1].quantity, Decimal('36.8179'))
         self.assertEqual(self.positions[1].costBasis,
                          helpers.cashUSD(Decimal('1801.19')))
 
     def test_uvxy(self) -> None:
-        self.assertEqual(self.positions[2].instrument, Stock('UVXY'))
+        self.assertEqual(self.positions[2].instrument,
+                         Stock('UVXY', Currency.USD))
         self.assertEqual(self.positions[2].quantity, Decimal('0'))
         self.assertEqual(self.positions[2].costBasis,
                          helpers.cashUSD(Decimal('0')))
 
     def test_vti(self) -> None:
-        self.assertEqual(self.positions[3].instrument, Stock('VTI'))
+        self.assertEqual(self.positions[3].instrument,
+                         Stock('VTI', Currency.USD))
         self.assertEqual(self.positions[3].quantity, Decimal('48.2304'))
         self.assertEqual(self.positions[3].costBasis,
                          helpers.cashUSD(Decimal('3283.04')))
@@ -60,7 +64,7 @@ class TestSchwabTransactions(unittest.TestCase):
     def test_buySecurity(self) -> None:
         ts = self.tradesByDate[date(2017, 2, 22)]
         self.assertEqual(len(ts), 1)
-        self.assertEqual(ts[0].instrument, Stock('VOO'))
+        self.assertEqual(ts[0].instrument, Stock('VOO', Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('23'))
         self.assertEqual(
             ts[0].amount,
@@ -72,7 +76,7 @@ class TestSchwabTransactions(unittest.TestCase):
     def test_reinvestShares(self) -> None:
         ts = self.tradesByDate[date(2017, 3, 29)]
         self.assertEqual(len(ts), 1)
-        self.assertEqual(ts[0].instrument, Stock('VOO'))
+        self.assertEqual(ts[0].instrument, Stock('VOO', Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('0.1062'))
         self.assertEqual(
             ts[0].amount,
@@ -85,7 +89,7 @@ class TestSchwabTransactions(unittest.TestCase):
         ts = self.tradesByDate[date(2018, 1, 2)]
         self.assertEqual(len(ts), 2)
 
-        self.assertEqual(ts[0].instrument, Stock('HD'))
+        self.assertEqual(ts[0].instrument, Stock('HD', Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('-6'))
         self.assertEqual(
             ts[0].amount,
@@ -94,7 +98,7 @@ class TestSchwabTransactions(unittest.TestCase):
                          Cash(currency=Currency.USD, quantity=Decimal('4.96')))
         self.assertEqual(ts[0].flags, TradeFlags.OPEN)
 
-        self.assertEqual(ts[1].instrument, Stock('HD'))
+        self.assertEqual(ts[1].instrument, Stock('HD', Currency.USD))
         self.assertEqual(ts[1].quantity, Decimal('6'))
         self.assertEqual(
             ts[1].amount,
@@ -109,6 +113,7 @@ class TestSchwabTransactions(unittest.TestCase):
         self.assertEqual(
             ts[0].instrument,
             Option(underlying='INTC',
+                   currency=Currency.USD,
                    optionType=OptionType.PUT,
                    expiration=date(2018, 12, 7),
                    strike=Decimal('48.50')))
@@ -125,6 +130,7 @@ class TestSchwabTransactions(unittest.TestCase):
         self.assertEqual(
             ts[0].instrument,
             Option(underlying='INTC',
+                   currency=Currency.USD,
                    optionType=OptionType.PUT,
                    expiration=date(2018, 12, 7),
                    strike=Decimal('48.50')))
@@ -141,6 +147,7 @@ class TestSchwabTransactions(unittest.TestCase):
         self.assertEqual(
             ts[2].instrument,
             Option(underlying='QQQ',
+                   currency=Currency.USD,
                    optionType=OptionType.CALL,
                    expiration=date(2018, 2, 1),
                    strike=Decimal('155')))
@@ -158,6 +165,7 @@ class TestSchwabTransactions(unittest.TestCase):
         self.assertEqual(
             ts[3].instrument,
             Option(underlying='QQQ',
+                   currency=Currency.USD,
                    optionType=OptionType.CALL,
                    expiration=date(2018, 2, 1),
                    strike=Decimal('130')))
@@ -175,6 +183,7 @@ class TestSchwabTransactions(unittest.TestCase):
         self.assertEqual(
             ts[0].instrument,
             Option(underlying='CSCO',
+                   currency=Currency.USD,
                    optionType=OptionType.PUT,
                    expiration=date(2018, 11, 30),
                    strike=Decimal('44.50')))
@@ -191,6 +200,7 @@ class TestSchwabTransactions(unittest.TestCase):
         self.assertEqual(
             ts[0].instrument,
             Option(underlying='MAR',
+                   currency=Currency.USD,
                    optionType=OptionType.CALL,
                    expiration=date(2018, 12, 28),
                    strike=Decimal('116')))
@@ -207,6 +217,7 @@ class TestSchwabTransactions(unittest.TestCase):
         self.assertEqual(
             ts[1].instrument,
             Option(underlying='MAR',
+                   currency=Currency.USD,
                    optionType=OptionType.CALL,
                    expiration=date(2018, 12, 28),
                    strike=Decimal('112')))
@@ -220,7 +231,7 @@ class TestSchwabTransactions(unittest.TestCase):
     def test_securityTransferSale(self) -> None:
         ts = self.tradesByDate[date(2018, 1, 4)]
         self.assertEqual(len(ts), 1)
-        self.assertEqual(ts[0].instrument, Stock('MSFT'))
+        self.assertEqual(ts[0].instrument, Stock('MSFT', Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('-10'))
         self.assertEqual(
             ts[0].amount,

--- a/tests/test_vanguard.py
+++ b/tests/test_vanguard.py
@@ -23,32 +23,38 @@ class TestVanguardPositions(unittest.TestCase):
             self.positions[0].instrument,
             Bond(
                 "U S TREASURY BILL CPN  0.00000 % MTD 2017-04-10 DTD 2017-08-14",
+                currency=Currency.USD,
                 validateSymbol=False))
         self.assertEqual(self.positions[0].quantity, 5000)
         # TODO: Validate cost basis
 
     def test_vmfxx(self) -> None:
-        self.assertEqual(self.positions[1].instrument, Stock("VMFXX"))
+        self.assertEqual(self.positions[1].instrument,
+                         Stock("VMFXX", Currency.USD))
         self.assertEqual(self.positions[1].quantity, Decimal('543.21'))
         # TODO: Validate cost basis
 
     def test_voo(self) -> None:
-        self.assertEqual(self.positions[2].instrument, Stock("VOO"))
+        self.assertEqual(self.positions[2].instrument,
+                         Stock("VOO", Currency.USD))
         self.assertEqual(self.positions[2].quantity, Decimal('100.1'))
         # TODO: Validate cost basis
 
     def test_vt(self) -> None:
-        self.assertEqual(self.positions[3].instrument, Stock("VT"))
+        self.assertEqual(self.positions[3].instrument,
+                         Stock("VT", Currency.USD))
         self.assertEqual(self.positions[3].quantity, Decimal('10'))
         # TODO: Validate cost basis
 
     def test_vti(self) -> None:
-        self.assertEqual(self.positions[4].instrument, Stock("VTI"))
+        self.assertEqual(self.positions[4].instrument,
+                         Stock("VTI", Currency.USD))
         self.assertEqual(self.positions[4].quantity, Decimal('50.5'))
         # TODO: Validate cost basis
 
     def test_vbr(self) -> None:
-        self.assertEqual(self.positions[5].instrument, Stock("VWO"))
+        self.assertEqual(self.positions[5].instrument,
+                         Stock("VWO", Currency.USD))
         self.assertEqual(self.positions[5].quantity, 20)
         # TODO: Validate cost basis
 
@@ -70,7 +76,7 @@ class TestVanguardTransactions(unittest.TestCase):
     def test_buySecurity(self) -> None:
         ts = self.tradesByDate[date(2016, 4, 20)]
         self.assertEqual(len(ts), 1)
-        self.assertEqual(ts[0].instrument, Stock('VTI'))
+        self.assertEqual(ts[0].instrument, Stock('VTI', Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('12'))
         self.assertEqual(
             ts[0].amount,
@@ -82,7 +88,7 @@ class TestVanguardTransactions(unittest.TestCase):
     def test_sellSecurity(self) -> None:
         ts = self.tradesByDate[date(2016, 10, 13)]
         self.assertEqual(len(ts), 1)
-        self.assertEqual(ts[0].instrument, Stock('VWO'))
+        self.assertEqual(ts[0].instrument, Stock('VWO', Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('-4'))
         self.assertEqual(
             ts[0].amount,
@@ -107,7 +113,7 @@ class TestVanguardTransactions(unittest.TestCase):
         ts = self.tradesByDate[date(2017, 2, 4)]
         self.assertEqual(len(ts), 2)
 
-        self.assertEqual(ts[0].instrument, Stock('VWO'))
+        self.assertEqual(ts[0].instrument, Stock('VWO', Currency.USD))
         self.assertEqual(ts[0].quantity, Decimal('0.123'))
         self.assertEqual(
             ts[0].amount,
@@ -116,7 +122,7 @@ class TestVanguardTransactions(unittest.TestCase):
                          Cash(currency=Currency.USD, quantity=Decimal('0.00')))
         self.assertEqual(ts[0].flags, TradeFlags.OPEN | TradeFlags.DRIP)
 
-        self.assertEqual(ts[1].instrument, Stock('VOO'))
+        self.assertEqual(ts[1].instrument, Stock('VOO', Currency.USD))
         self.assertEqual(ts[1].quantity, Decimal('0.321'))
         self.assertEqual(
             ts[1].amount,

--- a/vanguard.py
+++ b/vanguard.py
@@ -34,9 +34,9 @@ def guessInstrumentForInvestmentName(name: str) -> Instrument:
     instrument: Instrument
     if re.match(r'^.+\s\%\s.+$', name):
         # TODO: Determine valid CUSIP for bonds
-        instrument = Bond(name, validateSymbol=False)
+        instrument = Bond(name, currency=Currency.USD, validateSymbol=False)
     else:
-        instrument = Stock(name)
+        instrument = Stock(name, currency=Currency.USD)
 
     return instrument
 
@@ -49,7 +49,7 @@ def parseVanguardPosition(p: VanguardPosition,
                           trades: List[Trade]) -> Position:
     instrument: Instrument
     if len(p.symbol) > 0:
-        instrument = Stock(p.symbol)
+        instrument = Stock(p.symbol, currency=Currency.USD)
     else:
         instrument = guessInstrumentForInvestmentName(p.investmentName)
 
@@ -114,7 +114,7 @@ def forceParseVanguardTransaction(t: VanguardTransaction,
                                   flags: TradeFlags) -> Optional[Trade]:
     instrument: Instrument
     if len(t.symbol) > 0:
-        instrument = Stock(t.symbol)
+        instrument = Stock(t.symbol, currency=Currency.USD)
     else:
         instrument = guessInstrumentForInvestmentName(t.investmentName)
 


### PR DESCRIPTION
Resolves #8.

- [x] Convenience method to pull market data for all `Position`s, using the `bid` or `ask` as appropriate
- [x] Copy currency information from `Position` to `Instrument`
- [x] Implement hashing for models
- [x] Deeper tests of equality for models (e.g., `Instrument`)
- [x] ~~Deduplicate currency on `Position` if it makes sense somehow~~
- [x] Remove `currency` requirement from `Forex` specifically, as it's implied by the symbol
- [x] `Forex` symbol parsing
- [x] Fix `Forex` value fetching
- [x] Switch to historical data when live data is not available
- [x] Fix `Position` quantities being shown with a bunch of decimal places
- [x] Expose through CLI
- [x] ~~Tests for IB contract transformation (if possible)~~
- [x] Basic property-based tests for `Quote`
- [x] Track or figure out exchange?
- [x] Add `multiplier` to `Instrument` model, and use it in value calculations
- [x] Test `liveValuesForPositions()` with a stub
- [x] Add `Trade.price`, using contract multiplier