### PR TITLE
Migrate from .format() to f-strings

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
     docker:
       # specify the version you desire here
       # use `-browsers` prefix for selenium tests, e.g. `3.6.1-browsers`
-      - image: circleci/python:3.6.1
+      - image: circleci/python:3.6.2
 
       # Specify service dependencies here if necessary
       # CircleCI maintains a library of pre-built images

--- a/bankroll.py
+++ b/bankroll.py
@@ -113,20 +113,19 @@ def printPositions(args: Namespace) -> None:
         print(p)
 
         if p in values:
-            print('\tMarket value: {}'.format(values[p]))
+            print(f'\tMarket value: {values[p]}')
         elif args.live_value:
-            logging.warning('Could not fetch market value for {}'.format(
-                p.instrument))
+            logging.warning(f'Could not fetch market value for {p.instrument}')
 
         if not isinstance(p.instrument, Stock):
             continue
 
-        print('\tCost basis: {}'.format(p.costBasis))
+        print(f'\tCost basis: {p.costBasis}')
 
         if args.realized_basis:
             realizedBasis = analysis.realizedBasisForSymbol(
                 p.instrument.symbol, trades=trades)
-            print('\tRealized basis: {}'.format(realizedBasis))
+            print(f'\tRealized basis: {realizedBasis}')
 
 
 def printTrades(args: Namespace) -> None:

--- a/fidelity.py
+++ b/fidelity.py
@@ -57,8 +57,7 @@ def parseOptionsPosition(description: str) -> Option:
         description)
     if not match:
         raise ValueError(
-            'Could not parse Fidelity options description: {}'.format(
-                description))
+            f'Could not parse Fidelity options description: {description}')
 
     if match['putCall'] == 'PUT':
         optionType = OptionType.PUT
@@ -133,8 +132,7 @@ def parseOptionTransaction(symbol: str) -> Option:
         r'^-(?P<underlying>[A-Z]+)(?P<date>\d{6})(?P<putCall>C|P)(?P<strike>[0-9\.]+)$',
         symbol)
     if not match:
-        raise ValueError(
-            'Could not parse Fidelity options symbol: {}'.format(symbol))
+        raise ValueError(f'Could not parse Fidelity options symbol: {symbol}')
 
     if match['putCall'] == 'P':
         optionType = OptionType.PUT

--- a/ibkr.py
+++ b/ibkr.py
@@ -397,7 +397,7 @@ def contract(instrument: Instrument) -> IB.Contract:
     elif isinstance(instrument, Forex):
         return forexContract(instrument)
     else:
-        raise ValueError(f'Unexpected type of instrument: {repr(instrument)}')
+        raise ValueError(f'Unexpected type of instrument: {instrument!r}')
 
 
 # https://interactivebrokers.github.io/tws-api/market_data_type.html
@@ -423,7 +423,7 @@ class IBDataProvider(LiveDataProvider):
         self._client.qualifyContracts(con)
 
         ticker = self._client.reqTickers(con)[0]
-        logging.info(f'Received ticker: {repr(ticker)}')
+        logging.info(f'Received ticker: {ticker!r}')
 
         bid: Optional[Cash] = None
         ask: Optional[Cash] = None

--- a/ibkr.py
+++ b/ibkr.py
@@ -17,7 +17,7 @@ def parseFiniteDecimal(input: str) -> Decimal:
     with localcontext(ctx=Context(traps=[DivisionByZero, Overflow])):
         value = Decimal(input)
         if not value.is_finite():
-            raise ValueError('Input is not numeric: {}'.format(input))
+            raise ValueError(f'Input is not numeric: {input}')
 
         return value
 
@@ -31,7 +31,7 @@ def parseOption(symbol: str,
         r'^(?P<underlying>.{6})(?P<date>\d{6})(?P<putCall>P|C)(?P<strike>\d{8})$',
         symbol)
     if not match:
-        raise ValueError('Could not parse IB option symbol: {}'.format(symbol))
+        raise ValueError(f'Could not parse IB option symbol: {symbol}')
 
     if match['putCall'] == 'P':
         optionType = OptionType.PUT
@@ -48,14 +48,14 @@ def parseOption(symbol: str,
 def parseForex(symbol: str, currency: Currency) -> Forex:
     match = re.match(r'^(?P<base>[A-Z]{3})\.(?P<quote>[A-Z]{3})', symbol)
     if not match:
-        raise ValueError('Could not parse IB cash symbol: {}'.format(symbol))
+        raise ValueError(f'Could not parse IB cash symbol: {symbol}')
 
     baseCurrency = Currency[match['base']]
     quoteCurrency = Currency[match['quote']]
     if currency != quoteCurrency:
         raise ValueError(
-            'Expected quote currency {} to match position currency {}'.format(
-                quoteCurrency, currency))
+            f'Expected quote currency {quoteCurrency} to match position currency {currency}'
+        )
 
     return Forex(baseCurrency=baseCurrency, quoteCurrency=quoteCurrency)
 
@@ -67,8 +67,7 @@ def parseFutureOptionContract(contract: IB.Contract,
     elif contract.right.startswith('P'):
         optionType = OptionType.PUT
     else:
-        raise ValueError(
-            'Unexpected right in IB contract: {}'.format(contract))
+        raise ValueError(f'Unexpected right in IB contract: {contract}')
 
     return FutureOption(symbol=contract.localSymbol,
                         currency=currency,
@@ -86,7 +85,7 @@ def extractPosition(p: IB.Position) -> Position:
     symbol = p.contract.localSymbol
 
     if p.contract.currency not in Currency.__members__:
-        raise ValueError('Unrecognized currency in position: {}'.format(p))
+        raise ValueError(f'Unrecognized currency in position: {p}')
 
     currency = Currency[p.contract.currency]
 
@@ -117,8 +116,7 @@ def extractPosition(p: IB.Position) -> Position:
             instrument = parseForex(symbol=symbol, currency=currency)
         else:
             raise ValueError(
-                'Unrecognized/unsupported security type in position: {}'.
-                format(p))
+                f'Unrecognized/unsupported security type in position: {p}')
 
         qty = parseFiniteDecimal(p.position)
         costBasis = parseFiniteDecimal(p.avgCost) * qty
@@ -129,8 +127,8 @@ def extractPosition(p: IB.Position) -> Position:
                                        quantity=costBasis))
     except InvalidOperation:
         raise ValueError(
-            'One of the numeric position or contract values is out of range: {}'
-            .format(p))
+            f'One of the numeric position or contract values is out of range: {p}'
+        )
 
 
 def downloadPositions(ib: IB.IB, lenient: bool) -> List[Position]:
@@ -210,8 +208,7 @@ def parseFutureOptionTrade(trade: IBTradeConfirm) -> Instrument:
     elif trade.putCall == 'P':
         optionType = OptionType.PUT
     else:
-        raise ValueError(
-            'Unexpected value for putCall in IB trade: {}'.format(trade))
+        raise ValueError(f'Unexpected value for putCall in IB trade: {trade}')
 
     return FutureOption(symbol=trade.symbol,
                         currency=Currency[trade.currency],
@@ -227,10 +224,10 @@ def parseTradeConfirm(trade: IBTradeConfirm) -> Trade:
     tag = trade.assetCategory
     symbol = trade.symbol
     if not symbol:
-        raise ValueError('Missing symbol in trade: {}'.format(trade))
+        raise ValueError(f'Missing symbol in trade: {trade}')
 
     if trade.currency not in Currency.__members__:
-        raise ValueError('Unrecognized currency in trade: {}'.format(trade))
+        raise ValueError(f'Unrecognized currency in trade: {trade}')
 
     currency = Currency[trade.currency]
 
@@ -259,8 +256,7 @@ def parseTradeConfirm(trade: IBTradeConfirm) -> Trade:
             instrument = parseFutureOptionTrade(trade)
         else:
             raise ValueError(
-                'Unrecognized/unsupported security type in trade: {}'.format(
-                    trade))
+                f'Unrecognized/unsupported security type in trade: {trade}')
 
         flagsByCode = {
             'O': TradeFlags.OPEN,
@@ -284,8 +280,7 @@ def parseTradeConfirm(trade: IBTradeConfirm) -> Trade:
                 continue
 
             if c not in flagsByCode:
-                raise ValueError('Unrecognized code {} in trade: {}'.format(
-                    c, trade))
+                raise ValueError(f'Unrecognized code {c} in trade: {trade}')
 
             flags |= flagsByCode[c]
 
@@ -308,8 +303,7 @@ def parseTradeConfirm(trade: IBTradeConfirm) -> Trade:
                      flags=flags)
     except InvalidOperation:
         raise ValueError(
-            'One of the numeric trade values is out of range: {}'.format(
-                trade))
+            f'One of the numeric trade values is out of range: {trade}')
 
 
 def tradesFromReport(report: IB.FlexReport, lenient: bool) -> List[Trade]:
@@ -403,8 +397,7 @@ def contract(instrument: Instrument) -> IB.Contract:
     elif isinstance(instrument, Forex):
         return forexContract(instrument)
     else:
-        raise ValueError('Unexpected type of instrument: {}'.format(
-            repr(instrument)))
+        raise ValueError(f'Unexpected type of instrument: {repr(instrument)}')
 
 
 # https://interactivebrokers.github.io/tws-api/market_data_type.html
@@ -430,7 +423,7 @@ class IBDataProvider(LiveDataProvider):
         self._client.qualifyContracts(con)
 
         ticker = self._client.reqTickers(con)[0]
-        logging.info('Received ticker: {}'.format(repr(ticker)))
+        logging.info(f'Received ticker: {repr(ticker)}')
 
         bid: Optional[Cash] = None
         ask: Optional[Cash] = None

--- a/model.py
+++ b/model.py
@@ -21,24 +21,24 @@ class Currency(Enum):
 
     def format(self, quantity: Decimal) -> str:
         if quantity < 0:
-            return '({})'.format(self.format(abs(quantity)))
+            return f'({self.format(abs(quantity))})'
 
         if self == Currency.USD:
-            return '${:,.2f}'.format(quantity)
+            return f'${quantity:,.2f}'
         elif self == Currency.GBP:
-            return '£{:,.2f}'.format(quantity)
+            return f'£{quantity:,.2f}'
         elif self == Currency.AUD:
-            return 'AU${:,.2f}'.format(quantity)
+            return f'AU${quantity:,.2f}'
         elif self == Currency.EUR:
-            return '€{:,.2f}'.format(quantity)
+            return f'€{quantity:,.2f}'
         elif self == Currency.JPY:
-            return '¥{:,.0f}'.format(quantity)
+            return f'¥{quantity:,.0f}'
         elif self == Currency.CAD:
-            return 'C${:,.2f}'.format(quantity)
+            return f'C${quantity:,.2f}'
         elif self == Currency.NZD:
-            return 'NZ${:,.2f}'.format(quantity)
+            return f'NZ${quantity:,.2f}'
         else:
-            return '{} {:,}'.format(self.value, quantity)
+            return f'{self.value} {quantity:,}'
 
 
 T = TypeVar('T', Decimal, int)
@@ -54,7 +54,7 @@ class Cash:
     def __init__(self, currency: Currency, quantity: Decimal):
         if not quantity.is_finite():
             raise ValueError(
-                'Cash quantity {} is not a finite number'.format(quantity))
+                f'Cash quantity {quantity} is not a finite number')
 
         self._currency = currency
         self._quantity = self.quantize(quantity)
@@ -69,8 +69,7 @@ class Cash:
         return self._quantity
 
     def __repr__(self) -> str:
-        return 'Cash(currency={}, quantity={})'.format(repr(self.currency),
-                                                       repr(self.quantity))
+        return f'Cash(currency={self.currency!r}, quantity={self.quantity!r})'
 
     def __str__(self) -> str:
         return self.currency.format(self.quantity)
@@ -79,8 +78,7 @@ class Cash:
         if isinstance(other, Cash):
             if self.currency != other.currency:
                 raise ValueError(
-                    'Currency of {} must match {} for arithmetic'.format(
-                        self, other))
+                    f'Currency of {self} must match {other} for arithmetic')
 
             return Cash(currency=self.currency,
                         quantity=self.quantity + other.quantity)
@@ -91,8 +89,7 @@ class Cash:
         if isinstance(other, Cash):
             if self.currency != other.currency:
                 raise ValueError(
-                    'Currency of {} must match {} for arithmetic'.format(
-                        self, other))
+                    f'Currency of {self} must match {other} for arithmetic')
 
             return Cash(currency=self.currency,
                         quantity=self.quantity - other.quantity)
@@ -122,32 +119,28 @@ class Cash:
     def __lt__(self, other: 'Cash') -> bool:
         if self.currency != other.currency:
             raise ValueError(
-                'Currency of {} must match {} for comparison'.format(
-                    self, other))
+                f'Currency of {self} must match {other} for comparison')
 
         return self.quantity < other.quantity
 
     def __le__(self, other: 'Cash') -> bool:
         if self.currency != other.currency:
             raise ValueError(
-                'Currency of {} must match {} for comparison'.format(
-                    self, other))
+                f'Currency of {self} must match {other} for comparison')
 
         return self.quantity <= other.quantity
 
     def __gt__(self, other: 'Cash') -> bool:
         if self.currency != other.currency:
             raise ValueError(
-                'Currency of {} must match {} for comparison'.format(
-                    self, other))
+                f'Currency of {self} must match {other} for comparison')
 
         return self.quantity > other.quantity
 
     def __ge__(self, other: 'Cash') -> bool:
         if self.currency != other.currency:
             raise ValueError(
-                'Currency of {} must match {} for comparison'.format(
-                    self, other))
+                f'Currency of {self} must match {other} for comparison')
 
         return self.quantity >= other.quantity
 
@@ -213,9 +206,7 @@ class Instrument(ABC):
         return format(self.symbol, spec)
 
     def __repr__(self) -> str:
-        return '{}(symbol={}, currency={})'.format(repr(type(self)),
-                                                   repr(self.symbol),
-                                                   repr(self.currency))
+        return f'{type(self)!r}(symbol={self.symbol!r}, currency={self.currency!r})'
 
     def __str__(self) -> str:
         return self._symbol
@@ -239,8 +230,7 @@ class Bond(Instrument):
                  currency: Currency,
                  validateSymbol: bool = True):
         if validateSymbol and not self.validBondSymbol(symbol):
-            raise ValueError(
-                'Expected symbol to be a bond CUSIP: {}'.format(symbol))
+            raise ValueError(f'Expected symbol to be a bond CUSIP: {symbol}')
 
         super().__init__(symbol, currency)
 
@@ -271,11 +261,9 @@ class Option(Instrument):
         if not underlying:
             raise ValueError('Expected non-empty underlying symbol for Option')
         if not strike.is_finite() or strike <= 0:
-            raise ValueError(
-                'Expected positive strike price: {}'.format(strike))
+            raise ValueError(f'Expected positive strike price: {strike}')
         if not multiplier.is_finite() or multiplier <= 0:
-            raise ValueError(
-                'Expected positive multiplier: {}'.format(multiplier))
+            raise ValueError(f'Expected positive multiplier: {multiplier}')
 
         self._underlying = underlying
         self._optionType = optionType
@@ -285,9 +273,7 @@ class Option(Instrument):
 
         if symbol is None:
             # https://en.wikipedia.org/wiki/Option_symbol#The_OCC_Option_Symbol
-            symbol = '{:6}{}{}{:08.0f}'.format(underlying,
-                                               expiration.strftime('%y%m%d'),
-                                               optionType.value, strike * 1000)
+            symbol = f"{underlying:6}{expiration.strftime('%y%m%d')}{optionType.value}{(strike * 1000):08.0f}"
 
         super().__init__(symbol, currency)
 
@@ -312,10 +298,7 @@ class Option(Instrument):
         return self._multiplier
 
     def __repr__(self) -> str:
-        return '{}(underlying={}, optionType={}, expiration={}, strike={}, currency={}, multiplier={})'.format(
-            repr(type(self)), repr(self.underlying), repr(self.optionType),
-            repr(self.expiration), repr(self.strike), repr(self.currency),
-            repr(self.multiplier))
+        return f'{type(self)!r}(underlying={self.underlying!r}, optionType={self.optionType!r}, expiration={self.expiration!r}, strike={self.strike!r}, currency={self.currency!r}, multiplier={self.multiplier!r})'
 
 
 class FutureOption(Option):
@@ -335,8 +318,7 @@ class Future(Instrument):
     def __init__(self, symbol: str, currency: Currency, multiplier: Decimal,
                  expiration: date):
         if not multiplier.is_finite() or multiplier <= 0:
-            raise ValueError(
-                'Expected positive multiplier: {}'.format(multiplier))
+            raise ValueError(f'Expected positive multiplier: {multiplier}')
 
         self._multiplier = self.quantizeMultiplier(multiplier)
         self._expiration = expiration
@@ -352,21 +334,18 @@ class Future(Instrument):
         return self._expiration
 
     def __repr__(self) -> str:
-        return '{}(symbol={}, currency={}, multiplier={}, expiration={})'.format(
-            repr(type(self)), repr(self.symbol), repr(self.currency),
-            repr(self.multiplier), repr(self.expiration))
+        return f'{type(self)!r}(symbol={self.symbol!r}, currency={self.currency!r}, multiplier={self.multiplier!r}, expiration={self.expiration!r})'
 
 
 class Forex(Instrument):
     def __init__(self, baseCurrency: Currency, quoteCurrency: Currency):
         if baseCurrency == quoteCurrency:
             raise ValueError(
-                'Forex pair must be composed of different currencies, got {} and {}'
-                .format(repr(baseCurrency), repr(quoteCurrency)))
+                f'Forex pair must be composed of different currencies, got {baseCurrency!r} and {quoteCurrency!r}'
+            )
 
         self._baseCurrency = baseCurrency
-
-        symbol = '{}{}'.format(baseCurrency.name, quoteCurrency.name)
+        symbol = f'{baseCurrency.name}{quoteCurrency.name}'
         super().__init__(symbol, quoteCurrency)
 
     @property
@@ -378,9 +357,7 @@ class Forex(Instrument):
         return self._baseCurrency
 
     def __repr__(self) -> str:
-        return '{}(baseCurrency={}, quoteCurrency={})'.format(
-            repr(type(self)), repr(self.baseCurrency),
-            repr(self.quoteCurrency))
+        return f'{type(self)!r}(baseCurrency={self.baseCurrency!r}, quoteCurrency={self.quoteCurrency!r})'
 
 
 Item = TypeVar('Item')
@@ -401,14 +378,14 @@ class Quote:
                  last: Optional[Cash] = None,
                  close: Optional[Cash] = None):
         if bid and ask and ask < bid:
-            raise ValueError('Expected ask {} to be at least bid {}'.format(
-                ask, bid))
+            raise ValueError(f'Expected ask {ask} to be at least bid {bid}')
 
         if not allEqual(
             (price.currency
              for price in [bid, ask, last, close] if price is not None)):
-            raise ValueError('Currencies in a quote should match: {}'.format(
-                [bid, ask, last, close]))
+            raise ValueError(
+                f'Currencies in a quote should match: {[bid, ask, last, close]}'
+            )
 
         self._bid = bid
         self._ask = ask
@@ -442,8 +419,7 @@ class Quote:
         return hash((self.bid, self.ask, self.last, self.close))
 
     def __repr__(self) -> str:
-        return 'Quote(bid={}, ask={}, last={}, close={})'.format(
-            repr(self.bid), repr(self.ask), repr(self.last), repr(self.close))
+        return f'Quote(bid={self.bid!r}, ask={self.ask!r}, last={self.last!r}, close={self.close!r})'
 
 
 class LiveDataProvider(ABC):
@@ -464,19 +440,19 @@ class Position:
                  costBasis: Cash):
         if instrument.currency != costBasis.currency:
             raise ValueError(
-                'Cost basis {} should be in same currency as instrument {}'.
-                format(costBasis, instrument))
+                f'Cost basis {costBasis} should be in same currency as instrument {instrument}'
+            )
 
         if not quantity.is_finite():
             raise ValueError(
-                'Position quantity {} is not a finite number'.format(quantity))
+                f'Position quantity {quantity} is not a finite number')
 
         quantity = self.quantizeQuantity(quantity)
 
         if quantity == 0 and costBasis != 0:
             raise ValueError(
-                'Cost basis {} should be zero if quantity is zero'.format(
-                    repr(costBasis)))
+                f'Cost basis {repr(costBasis)} should be zero if quantity is zero'
+            )
 
         self._instrument = instrument
         self._quantity = quantity
@@ -486,8 +462,8 @@ class Position:
     def combine(self, other: 'Position') -> 'Position':
         if self.instrument != other.instrument:
             raise ValueError(
-                'Cannot combine positions in two different instruments: {} and {}'
-                .format(self.instrument, other.instrument))
+                f'Cannot combine positions in two different instruments: {self.instrument} and {other.instrument}'
+            )
 
         return Position(instrument=self.instrument,
                         quantity=self.quantity + other.quantity,
@@ -523,13 +499,10 @@ class Position:
         return self._costBasis
 
     def __repr__(self) -> str:
-        return 'Position(instrument={}, quantity={}, costBasis={})'.format(
-            repr(self.instrument), repr(self.quantity), repr(self.costBasis))
+        return f'Position(instrument={self.instrument!r}, quantity={self.quantity!r}, costBasis={self.costBasis!r})'
 
     def __str__(self) -> str:
-        return '{:21} {:>14,f} @ {}'.format(self.instrument,
-                                            self.quantity.normalize(),
-                                            self.averagePrice)
+        return f'{self.instrument:21} {self.quantity.normalize():>14,f} @ {self.averagePrice}'
 
 
 class TradeFlags(Flag):
@@ -553,7 +526,7 @@ class Trade:
                  flags: TradeFlags):
         if not quantity.is_finite():
             raise ValueError(
-                'Trade quantity {} is not a finite number'.format(quantity))
+                f'Trade quantity {quantity} is not a finite number')
 
         if flags not in [
                 TradeFlags.OPEN, TradeFlags.CLOSE,
@@ -562,7 +535,7 @@ class Trade:
                 TradeFlags.CLOSE | TradeFlags.EXPIRED,
                 TradeFlags.CLOSE | TradeFlags.ASSIGNED_OR_EXERCISED
         ]:
-            raise ValueError('Invalid combination of flags: {}'.format(flags))
+            raise ValueError(f'Invalid combination of flags: {flags}')
 
         self._date = date
         self._instrument = instrument
@@ -622,19 +595,14 @@ class Trade:
                      self.fees, self.flags))
 
     def __repr__(self) -> str:
-        return 'Trade(date={}, instrument={}, quantity={}, amount={}, fees={}, flags={})'.format(
-            repr(self.date), repr(self.instrument), repr(self.quantity),
-            repr(self.amount), repr(self.fees), repr(self.flags))
+        return f'Trade(date={self.date!r}, instrument={self.instrument!r}, quantity={self.quantity!r}, amount={self.amount!r}, fees={self.fees!r}, flags={self.flags!r})'
 
     def __str__(self) -> str:
         if self.quantity > 0:
             action = 'Buy'
         else:
             action = 'Sell'
-
-        return '{} {} {} {}: {} (before {} in fees)'.format(
-            self.date.date(), action, abs(self.quantity), self.instrument,
-            self.amount, self.fees)
+        return f'{self.date.date()} {action} {abs(self.quantity)} {self.instrument}: {self.amount} (before {self.fees} in fees)'
 
     def _replace(self, **kwargs: Any) -> 'Trade':
         vals: Dict[str, Any] = {

--- a/model.py
+++ b/model.py
@@ -451,8 +451,7 @@ class Position:
 
         if quantity == 0 and costBasis != 0:
             raise ValueError(
-                f'Cost basis {repr(costBasis)} should be zero if quantity is zero'
-            )
+                f'Cost basis {costBasis!r} should be zero if quantity is zero')
 
         self._instrument = instrument
         self._quantity = quantity

--- a/parsetools.py
+++ b/parsetools.py
@@ -14,7 +14,7 @@ def lenientParse(xs: Iterable[T], transform: Callable[[T], U],
         except ValueError as err:
             if lenient:
                 warn(
-                    'Failed to parse {}: {}'.format(input, err),
+                    f'Failed to parse {input}: {err}',
                     category=RuntimeWarning,
                     # Pop all the way out of lenientParse() to show the warning
                     stacklevel=4)

--- a/schwab.py
+++ b/schwab.py
@@ -21,8 +21,7 @@ def parseOption(symbol: str) -> Option:
         r'^(?P<underlying>[A-Z0-9/]+) (?P<month>\d{2})/(?P<day>\d{2})/(?P<year>\d{4}) (?P<strike>[0-9\.]+) (?P<putCall>P|C)$',
         symbol)
     if not match:
-        raise ValueError(
-            'Could not parse Schwab options symbol: {}'.format(symbol))
+        raise ValueError(f'Could not parse Schwab options symbol: {symbol}')
 
     if match['putCall'] == 'P':
         optionType = OptionType.PUT
@@ -74,8 +73,7 @@ def parseSchwabPosition(p: SchwabPosition) -> Optional[Position]:
     elif re.match(r'Fixed Income', p.securityType):
         instrument = Bond(p.symbol, currency=Currency.USD)
     else:
-        raise ValueError('Unrecognized security type: {}'.format(
-            p.securityType))
+        raise ValueError(f'Unrecognized security type: {p.securityType}')
 
     return Position(instrument=instrument,
                     quantity=schwabDecimal(p.quantity),

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -128,22 +128,17 @@ class TestCash(unittest.TestCase):
         cashB = Cash(currency=cur, quantity=a + b)
         self.assertLessEqual(cashA,
                              cashB,
-                             msg='{} not less than itself plus {}: {}'.format(
-                                 a, b, a + b))
+                             msg=f'{a} not less than itself plus {b}: {a + b}')
         self.assertGreaterEqual(
-            cashB,
-            cashA,
-            msg='{} plus {} not greater than itself: {}'.format(a, b, a + b))
+            cashB, cashA, msg=f'{a} plus {b} not greater than itself: {a + b}')
 
         cashB = Cash(currency=cur, quantity=a - b)
-        self.assertLessEqual(cashB,
-                             cashA,
-                             msg='{} minus {} not less than itself: {}'.format(
-                                 a, b, a - b))
+        self.assertLessEqual(
+            cashB, cashA, msg=f'{a} minus {b} not less than itself: {a - b}')
         self.assertGreaterEqual(
             cashA,
             cashB,
-            msg='{} not greater than itself minus {}: {}'.format(a, b, a - b))
+            msg=f'{a} not greater than itself minus {b}: {a - b}')
 
 
 class TestPosition(unittest.TestCase):


### PR DESCRIPTION
This swaps out usage of `str.format()` with [literal string interpolation](https://www.python.org/dev/peps/pep-0498/), aka f-strings.

In addition, instances of `repr(expr)` were replaced with `{expr!r}`.