### PR TITLE
Fix incorrect realized basis when ticker symbols have different separators

### DIFF
--- a/analysis.py
+++ b/analysis.py
@@ -3,11 +3,21 @@ from model import Cash, Trade, Instrument, Option, LiveDataProvider, Quote, Posi
 from progress.bar import Bar
 from typing import Dict, Iterable, Optional, Tuple
 
+import re
+
+
+# Different brokers represent "identical" symbols differently, and they can all be valid.
+# This function normalizes them so they can be compared across time and space.
+def normalizeSymbol(symbol: str) -> str:
+    # These issues mostly show up with separators for multi-class shares (like BRK A and B)
+    return re.sub(r'[\.\s/]', '', symbol)
+
 
 def tradeAffectsSymbol(trade: Trade, symbol: str) -> bool:
-    return (isinstance(trade.instrument, Option)
-            and trade.instrument.underlying == symbol
-            ) or trade.instrument.symbol == symbol
+    return (isinstance(trade.instrument, Option) and normalizeSymbol(
+        trade.instrument.underlying) == normalizeSymbol(symbol)
+            ) or normalizeSymbol(
+                trade.instrument.symbol) == normalizeSymbol(symbol)
 
 
 # Calculates the "realized" basis for a particular symbol, given a trade history. This refers to the actual amounts paid in and out, including dividend payments, as well as money gained or lost on derivatives related to that symbol (e.g., short puts, covered calls).

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -1,4 +1,4 @@
-from analysis import realizedBasisForSymbol, liveValuesForPositions
+from analysis import normalizeSymbol, realizedBasisForSymbol, liveValuesForPositions
 from datetime import datetime, date
 from decimal import Decimal
 from hypothesis import given, reproduce_failure, seed
@@ -79,6 +79,10 @@ class TestAnalysis(unittest.TestCase):
         self.assertEqual(basis, helpers.cashUSD(Decimal('900')))
 
     separatedSymbols = ['BRK.B', 'BRKB', 'BRK B', 'BRK/B']
+
+    @given(sampled_from(separatedSymbols))
+    def test_normalizeSymbol(self, symbol: str) -> None:
+        self.assertEqual(normalizeSymbol(symbol), 'BRKB')
 
     @given(lists(sampled_from(separatedSymbols), min_size=3, max_size=3))
     def test_realizedBasisWithSeparatedSymbol(self,

--- a/tests/test_analysis.py
+++ b/tests/test_analysis.py
@@ -2,7 +2,7 @@ from analysis import realizedBasisForSymbol, liveValuesForPositions
 from datetime import datetime, date
 from decimal import Decimal
 from hypothesis import given, reproduce_failure, seed
-from hypothesis.strategies import builds, composite, dates, datetimes, decimals, from_type, iterables, just, lists, one_of, text, tuples, SearchStrategy
+from hypothesis.strategies import builds, composite, dates, datetimes, decimals, from_type, iterables, just, lists, one_of, sampled_from, text, tuples, SearchStrategy
 from model import Cash, Currency, Instrument, Stock, Option, OptionType, Quote, Trade, TradeFlags, LiveDataProvider, Position
 from typing import Any, Dict, Iterable, List, Tuple, no_type_check
 
@@ -76,6 +76,33 @@ class TestAnalysis(unittest.TestCase):
         ]
 
         basis = realizedBasisForSymbol('SPY', trades=trades)
+        self.assertEqual(basis, helpers.cashUSD(Decimal('900')))
+
+    separatedSymbols = ['BRK.B', 'BRKB', 'BRK B', 'BRK/B']
+
+    @given(lists(sampled_from(separatedSymbols), min_size=3, max_size=3))
+    def test_realizedBasisWithSeparatedSymbol(self,
+                                              symbols: List[str]) -> None:
+        trades = [
+            Trade(date=datetime.now(),
+                  instrument=Stock(symbols[0], Currency.USD),
+                  quantity=Decimal('5'),
+                  amount=helpers.cashUSD(Decimal('-999')),
+                  fees=helpers.cashUSD(Decimal('1')),
+                  flags=TradeFlags.OPEN),
+            Trade(date=datetime.now(),
+                  instrument=Option(underlying=symbols[1],
+                                    currency=Currency.USD,
+                                    optionType=OptionType.CALL,
+                                    expiration=date.today(),
+                                    strike=Decimal('123')),
+                  quantity=Decimal('1'),
+                  amount=helpers.cashUSD(Decimal('101')),
+                  fees=helpers.cashUSD(Decimal('1')),
+                  flags=TradeFlags.OPEN),
+        ]
+
+        basis = realizedBasisForSymbol(symbols[2], trades=trades)
         self.assertEqual(basis, helpers.cashUSD(Decimal('900')))
 
     @no_type_check


### PR DESCRIPTION
In my case, this occurred due to a change in how the separator was represented. Resolves #25.