### PR TITLE
Unify brokerage interfaces

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -46,6 +46,10 @@ jobs:
           key: v1-dependencies-{{ checksum "requirements.txt" }}
 
       - run:
+          name: typecheck
+          command: script/typecheck
+
+      - run:
           name: run tests
           command: script/test
       

--- a/README.md
+++ b/README.md
@@ -166,6 +166,8 @@ More detailed instructions have yet to be written—[contributions welcome](CONT
 
 `bankroll` intends to abstract away broker-specific details as much as possible, to minimize the work required to support each one, so if your broker isn't listed above, please consider [contributing](CONTRIBUTING.md) an implementation for them! We want the list to grow over time, because it's extremely useful to be able to aggregate and analyze data across multiple brokers at once.
 
+To add a new brokerage, create a new subclass of [`AccountData`](bankroll/model/account.py), then implement the methods as required by the interface. As long as the new subclass is loaded at runtime, it will be automatically included in functionality like [data aggregation](bankroll/aggregator.py).
+
 # Saving configuration
 
 To preserve settings across runs, all of the command-line arguments demonstrated above can also be saved into an [INI file](https://docs.python.org/3/library/configparser.html#supported-ini-file-structure). The configuration file is especially useful to store default values, because when a setting is specified in a configuration file _as well as_ on the command line, the command-line argument will take precedence.

--- a/bankroll/__init__.py
+++ b/bankroll/__init__.py
@@ -1,4 +1,4 @@
-from .aggregator import DataAggregator
+from .aggregator import AccountAggregator
 from .analysis import *
 from .brokers import *
 from .model import *

--- a/bankroll/__main__.py
+++ b/bankroll/__main__.py
@@ -70,19 +70,20 @@ readVanguardSettings = addSettingsToArgumentGroup(vanguard.Settings,
                                                   vanguardGroup)
 
 
-def printPositions(data: AccountAggregator, args: Namespace) -> None:
+def printPositions(accounts: AccountAggregator, args: Namespace) -> None:
     values: Dict[Position, Cash] = {}
     if args.live_value:
-        if data.dataProvider:
+        dataProvider = accounts.marketDataProvider
+        if dataProvider:
             values = analysis.liveValuesForPositions(
-                data.positions,
-                dataProvider=data.dataProvider,
+                accounts.positions(),
+                dataProvider=dataProvider,
                 progressBar=Bar('Loading market data for positions'))
         else:
             logging.error(
                 'Live data connection required to fetch market values')
 
-    for p in sorted(data.positions, key=lambda p: p.instrument):
+    for p in sorted(accounts.positions(), key=lambda p: p.instrument):
         print(p)
 
         if p in values:
@@ -94,12 +95,12 @@ def printPositions(data: AccountAggregator, args: Namespace) -> None:
 
         if args.realized_basis and isinstance(p.instrument, Stock):
             realizedBasis = analysis.realizedBasisForSymbol(
-                p.instrument.symbol, activity=data.activity)
+                p.instrument.symbol, activity=accounts.activity())
             print(f'\tRealized basis: {realizedBasis}')
 
 
-def printActivity(data: AccountAggregator, args: Namespace) -> None:
-    for t in sorted(data.activity, key=lambda t: t.date, reverse=True):
+def printActivity(accounts: AccountAggregator, args: Namespace) -> None:
+    for t in sorted(accounts.activity(), key=lambda t: t.date, reverse=True):
         print(t)
 
 
@@ -148,8 +149,9 @@ def main() -> None:
             readVanguardSettings(config, args).items(),
             readIBSettings(config, args).items()))
 
-    data = AccountAggregator(mergedSettings).loadData(lenient=args.lenient)
-    commands[args.command](data, args)
+    accounts = AccountAggregator.fromSettings(mergedSettings,
+                                              lenient=args.lenient)
+    commands[args.command](accounts, args)
 
 
 if __name__ == '__main__':

--- a/bankroll/__main__.py
+++ b/bankroll/__main__.py
@@ -1,6 +1,6 @@
 from argparse import ArgumentParser, Namespace
 from itertools import chain
-from bankroll import Activity, Instrument, Stock, Position, Trade, Cash, MarketDataProvider, DataAggregator, analysis
+from bankroll import Activity, Instrument, Stock, Position, Trade, Cash, MarketDataProvider, AccountAggregator, analysis
 from bankroll.brokers import *
 from bankroll.configuration import Configuration, Settings, addSettingsToArgumentGroup
 from progress.bar import Bar
@@ -70,7 +70,7 @@ readVanguardSettings = addSettingsToArgumentGroup(vanguard.Settings,
                                                   vanguardGroup)
 
 
-def printPositions(data: DataAggregator, args: Namespace) -> None:
+def printPositions(data: AccountAggregator, args: Namespace) -> None:
     values: Dict[Position, Cash] = {}
     if args.live_value:
         if data.dataProvider:
@@ -98,7 +98,7 @@ def printPositions(data: DataAggregator, args: Namespace) -> None:
             print(f'\tRealized basis: {realizedBasis}')
 
 
-def printActivity(data: DataAggregator, args: Namespace) -> None:
+def printActivity(data: AccountAggregator, args: Namespace) -> None:
     for t in sorted(data.activity, key=lambda t: t.date, reverse=True):
         print(t)
 
@@ -148,7 +148,7 @@ def main() -> None:
             readVanguardSettings(config, args).items(),
             readIBSettings(config, args).items()))
 
-    data = DataAggregator(mergedSettings).loadData(lenient=args.lenient)
+    data = AccountAggregator(mergedSettings).loadData(lenient=args.lenient)
     commands[args.command](data, args)
 
 

--- a/bankroll/aggregator.py
+++ b/bankroll/aggregator.py
@@ -20,7 +20,7 @@ class AccountAggregator(AccountData):
 
     @classmethod
     def fromSettings(cls, settings: Mapping[Settings, str],
-                     lenient: bool) -> AccountAggregator:
+                     lenient: bool) -> 'AccountAggregator':
         return AccountAggregator(accounts=[
             fidelity.FidelityAccount.fromSettings(settings, lenient=lenient),
             ibkr.IBAccount.fromSettings(settings, lenient=lenient),

--- a/bankroll/aggregator.py
+++ b/bankroll/aggregator.py
@@ -1,17 +1,13 @@
+from itertools import chain
+from typing import Dict, Iterable, Mapping, Optional, Sequence
+
 from bankroll.analysis import deduplicatePositions
 from bankroll.brokers import *
-from bankroll.model import Activity, Position, MarketDataProvider
 from bankroll.configuration import Configuration, Settings
-from itertools import chain
-from pathlib import Path
-from typing import Dict, List, Mapping, Optional, Sequence
+from bankroll.model import AccountData, Activity, MarketDataProvider, Position
 
 
-class DataAggregator:
-    _positions: List[Position]
-    _activity: List[Activity]
-    _dataProvider: Optional[MarketDataProvider]
-
+class DataAggregator(AccountData):
     @classmethod
     def allSettings(cls, config: Configuration = Configuration()
                     ) -> Dict[Settings, str]:
@@ -22,67 +18,35 @@ class DataAggregator:
                 config.section(schwab.Settings).items(),
                 config.section(vanguard.Settings).items()))
 
-    def __init__(self, settings: Mapping[Settings, str]):
-        self._settings = dict(settings)
-        self._positions = []
-        self._activity = []
-        self._dataProvider = None
+    @classmethod
+    def fromSettings(cls, settings: Mapping[Settings, str],
+                     lenient: bool) -> DataAggregator:
+        return DataAggregator(accounts=[
+            fidelity.FidelityAccount.fromSettings(settings, lenient=lenient),
+            ibkr.IBAccount.fromSettings(settings, lenient=lenient),
+            schwab.SchwabAccount.fromSettings(settings, lenient=lenient),
+            vanguard.VanguardAccount.fromSettings(settings, lenient=lenient),
+        ],
+                              lenient=lenient)
+
+    def __init__(self, accounts: Sequence[AccountData], lenient: bool):
+        self._accounts = accounts
+        self._lenient = lenient
         super().__init__()
 
-    def loadData(self, lenient: bool) -> 'DataAggregator':
-        fidelityPositions = self._settings.get(fidelity.Settings.POSITIONS)
-        if fidelityPositions:
-            self._positions += fidelity.parsePositions(Path(fidelityPositions),
-                                                       lenient=lenient)
+    def positions(self) -> Iterable[Position]:
+        # TODO: Memoize the result of deduplication?
+        return deduplicatePositions(
+            chain.from_iterable(
+                (account.positions() for account in self._accounts)))
 
-        fidelityTransactions = self._settings.get(
-            fidelity.Settings.TRANSACTIONS)
-        if fidelityTransactions:
-            self._activity += fidelity.parseTransactions(
-                Path(fidelityTransactions), lenient=lenient)
-
-        schwabPositions = self._settings.get(schwab.Settings.POSITIONS)
-        if schwabPositions:
-            self._positions += schwab.parsePositions(Path(schwabPositions),
-                                                     lenient=lenient)
-
-        schwabTransactions = self._settings.get(schwab.Settings.TRANSACTIONS)
-        if schwabTransactions:
-            self._activity += schwab.parseTransactions(
-                Path(schwabTransactions), lenient=lenient)
-
-        vanguardStatement = self._settings.get(vanguard.Settings.STATEMENT)
-        if vanguardStatement:
-            positionsAndActivity = vanguard.parsePositionsAndActivity(
-                Path(vanguardStatement), lenient=lenient)
-            self._positions += positionsAndActivity.positions
-            self._activity += positionsAndActivity.activity
-
-        ibSettings = {
-            k: v
-            for k, v in self._settings.items() if isinstance(k, ibkr.Settings)
-        }
-
-        (ibPositions, ibActivity,
-         ib) = ibkr.loadPositionsAndActivity(ibSettings, lenient=lenient)
-
-        self._positions += ibPositions
-        self._activity += ibActivity
-
-        if ib and not self._dataProvider:
-            self._dataProvider = ibkr.IBDataProvider(ib)
-
-        self._positions = list(deduplicatePositions(self._positions))
-        return self
+    def activity(self) -> Iterable[Activity]:
+        return chain.from_iterable(
+            (account.activity() for account in self._accounts))
 
     @property
-    def positions(self) -> Sequence[Position]:
-        return self._positions
-
-    @property
-    def activity(self) -> Sequence[Activity]:
-        return self._activity
-
-    @property
-    def dataProvider(self) -> Optional[MarketDataProvider]:
-        return self._dataProvider
+    def marketDataProvider(self) -> Optional[MarketDataProvider]:
+        # Don't retrieve data providers twice to check for None, in case
+        # they're expensive to construct.
+        return next((p for p in (account.marketDataProvider
+                                 for account in self._accounts) if p), None)

--- a/bankroll/aggregator.py
+++ b/bankroll/aggregator.py
@@ -7,7 +7,7 @@ from bankroll.configuration import Configuration, Settings
 from bankroll.model import AccountData, Activity, MarketDataProvider, Position
 
 
-class DataAggregator(AccountData):
+class AccountAggregator(AccountData):
     @classmethod
     def allSettings(cls, config: Configuration = Configuration()
                     ) -> Dict[Settings, str]:
@@ -20,14 +20,14 @@ class DataAggregator(AccountData):
 
     @classmethod
     def fromSettings(cls, settings: Mapping[Settings, str],
-                     lenient: bool) -> DataAggregator:
-        return DataAggregator(accounts=[
+                     lenient: bool) -> AccountAggregator:
+        return AccountAggregator(accounts=[
             fidelity.FidelityAccount.fromSettings(settings, lenient=lenient),
             ibkr.IBAccount.fromSettings(settings, lenient=lenient),
             schwab.SchwabAccount.fromSettings(settings, lenient=lenient),
             vanguard.VanguardAccount.fromSettings(settings, lenient=lenient),
         ],
-                              lenient=lenient)
+                                 lenient=lenient)
 
     def __init__(self, accounts: Sequence[AccountData], lenient: bool):
         self._accounts = accounts

--- a/bankroll/brokers/fidelity.py
+++ b/bankroll/brokers/fidelity.py
@@ -94,7 +94,7 @@ def _parseOptionsPosition(description: str) -> Option:
                   strike=Decimal(match['strike']))
 
 
-def parsePositions(path: Path, lenient: bool = False) -> List[Position]:
+def _parsePositions(path: Path, lenient: bool = False) -> List[Position]:
     with open(path, newline='') as csvfile:
         stocksCriterion = CSVSectionCriterion(startSectionRowMatch=["Stocks"],
                                               endSectionRowMatch=[""],
@@ -228,7 +228,7 @@ def _parseFidelityTransaction(t: _FidelityTransaction) -> Optional[Activity]:
 
 
 # Transactions will be ordered from newest to oldest
-def parseTransactions(path: Path, lenient: bool = False) -> List[Activity]:
+def _parseTransactions(path: Path, lenient: bool = False) -> List[Activity]:
     with open(path, newline='') as csvfile:
         transactionsCriterion = CSVSectionCriterion(
             startSectionRowMatch=["Run Date", "Account", "Action"],
@@ -277,8 +277,8 @@ class FidelityAccount(AccountData):
             return []
 
         if not self._positions:
-            self._positions = parsePositions(self._positionsPath,
-                                             lenient=self._lenient)
+            self._positions = _parsePositions(self._positionsPath,
+                                              lenient=self._lenient)
 
         return self._positions
 
@@ -287,7 +287,7 @@ class FidelityAccount(AccountData):
             return []
 
         if not self._activity:
-            self._activity = parseTransactions(self._transactionsPath,
-                                               lenient=self._lenient)
+            self._activity = _parseTransactions(self._transactionsPath,
+                                                lenient=self._lenient)
 
         return self._activity

--- a/bankroll/brokers/fidelity.py
+++ b/bankroll/brokers/fidelity.py
@@ -250,8 +250,8 @@ def parseTransactions(path: Path, lenient: bool = False) -> List[Activity]:
 
 
 class FidelityAccount(AccountData):
-    _positions: Optional[Sequence[Position]]
-    _activity: Optional[Sequence[Activity]]
+    _positions: Optional[Sequence[Position]] = None
+    _activity: Optional[Sequence[Activity]] = None
 
     @classmethod
     def fromSettings(cls, settings: Mapping[configuration.Settings, str],

--- a/bankroll/brokers/fidelity.py
+++ b/bankroll/brokers/fidelity.py
@@ -6,7 +6,7 @@ from decimal import Decimal
 from enum import IntEnum, unique
 from pathlib import Path
 from sys import stderr
-from typing import Callable, Dict, Iterable, List, NamedTuple, Optional, Sequence, Set
+from typing import Callable, Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Set
 from warnings import warn
 
 import bankroll.configuration as configuration
@@ -252,6 +252,16 @@ def parseTransactions(path: Path, lenient: bool = False) -> List[Activity]:
 class FidelityAccount(AccountData):
     _positions: Optional[Sequence[Position]]
     _activity: Optional[Sequence[Activity]]
+
+    @classmethod
+    def fromSettings(cls, settings: Mapping[configuration.Settings, str],
+                     lenient: bool) -> 'FidelityAccount':
+        positions = settings.get(Settings.POSITIONS)
+        transactions = settings.get(Settings.TRANSACTIONS)
+
+        return cls(positions=Path(positions) if positions else None,
+                   transactions=Path(transactions) if transactions else None,
+                   lenient=lenient)
 
     def __init__(self,
                  positions: Optional[Path] = None,

--- a/bankroll/brokers/ibkr.py
+++ b/bankroll/brokers/ibkr.py
@@ -680,6 +680,35 @@ class IBAccount(AccountData):
     _cachedActivity: Optional[Sequence[Activity]]
     _client: Optional[IB.IB]
 
+    @classmethod
+    def fromSettings(cls, settings: Mapping[configuration.Settings, str],
+                     lenient: bool) -> 'IBAccount':
+        port = settings.get(Settings.TWS_PORT)
+
+        tradesSetting = settings.get(Settings.TRADES)
+        trades: Union[Path, int, None]
+        if tradesSetting:
+            path = Path(tradesSetting)
+            if path.is_file():
+                trades = path
+            else:
+                trades = int(tradesSetting)
+
+        activitySetting = settings.get(Settings.ACTIVITY)
+        activity: Union[Path, int, None]
+        if activitySetting:
+            path = Path(activitySetting)
+            if path.is_file():
+                activity = path
+            else:
+                activity = int(activitySetting)
+
+        return cls(twsPort=int(port) if port else None,
+                   flexToken=settings.get(Settings.FLEX_TOKEN),
+                   trades=trades,
+                   activity=activity,
+                   lenient=lenient)
+
     def __init__(self,
                  twsPort: Optional[int] = None,
                  flexToken: Optional[str] = None,

--- a/bankroll/brokers/ibkr.py
+++ b/bankroll/brokers/ibkr.py
@@ -677,8 +677,8 @@ class IBDataProvider(MarketDataProvider):
 
 
 class IBAccount(AccountData):
-    _cachedActivity: Optional[Sequence[Activity]]
-    _client: Optional[IB.IB]
+    _cachedActivity: Optional[Sequence[Activity]] = None
+    _client: Optional[IB.IB] = None
 
     @classmethod
     def fromSettings(cls, settings: Mapping[configuration.Settings, str],

--- a/bankroll/brokers/schwab.py
+++ b/bankroll/brokers/schwab.py
@@ -1,4 +1,4 @@
-from bankroll.model import Activity, Cash, Currency, Instrument, Stock, Bond, Option, OptionType, Position, CashPayment, Trade, TradeFlags
+from bankroll.model import AccountData, Activity, Cash, Currency, Instrument, Stock, Bond, Option, OptionType, Position, CashPayment, Trade, TradeFlags
 from bankroll.parsetools import lenientParse
 from datetime import date, datetime
 from decimal import Decimal
@@ -339,3 +339,37 @@ def _fixUpShortSales(activity: Sequence[Activity],
 
     # Start from oldest transactions, work to newer
     return [f(t) for t in reversed(activity)]
+
+
+class SchwabAccount(AccountData):
+    _positions: Optional[Sequence[Position]]
+    _activity: Optional[Sequence[Activity]]
+
+    def __init__(self,
+                 positions: Optional[Path] = None,
+                 transactions: Optional[Path] = None,
+                 lenient: bool = False):
+        self._positionsPath = positions
+        self._transactionsPath = transactions
+        self._lenient = lenient
+        super().__init__()
+
+    def positions(self) -> Iterable[Position]:
+        if not self._positionsPath:
+            return []
+
+        if not self._positions:
+            self._positions = parsePositions(self._positionsPath,
+                                             lenient=self._lenient)
+
+        return self._positions
+
+    def activity(self) -> Iterable[Activity]:
+        if not self._transactionsPath:
+            return []
+
+        if not self._activity:
+            self._activity = parseTransactions(self._transactionsPath,
+                                               lenient=self._lenient)
+
+        return self._activity

--- a/bankroll/brokers/schwab.py
+++ b/bankroll/brokers/schwab.py
@@ -342,8 +342,8 @@ def _fixUpShortSales(activity: Sequence[Activity],
 
 
 class SchwabAccount(AccountData):
-    _positions: Optional[Sequence[Position]]
-    _activity: Optional[Sequence[Activity]]
+    _positions: Optional[Sequence[Position]] = None
+    _activity: Optional[Sequence[Activity]] = None
 
     @classmethod
     def fromSettings(cls, settings: Mapping[configuration.Settings, str],

--- a/bankroll/brokers/schwab.py
+++ b/bankroll/brokers/schwab.py
@@ -5,7 +5,7 @@ from decimal import Decimal
 from enum import unique
 from itertools import chain, groupby
 from pathlib import Path
-from typing import Dict, Iterable, List, NamedTuple, Optional, Sequence, TypeVar
+from typing import Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Type, TypeVar
 
 import bankroll.configuration as configuration
 import csv
@@ -344,6 +344,16 @@ def _fixUpShortSales(activity: Sequence[Activity],
 class SchwabAccount(AccountData):
     _positions: Optional[Sequence[Position]]
     _activity: Optional[Sequence[Activity]]
+
+    @classmethod
+    def fromSettings(cls, settings: Mapping[configuration.Settings, str],
+                     lenient: bool) -> 'SchwabAccount':
+        positions = settings.get(Settings.POSITIONS)
+        transactions = settings.get(Settings.TRANSACTIONS)
+
+        return cls(positions=Path(positions) if positions else None,
+                   transactions=Path(transactions) if transactions else None,
+                   lenient=lenient)
 
     def __init__(self,
                  positions: Optional[Path] = None,

--- a/bankroll/brokers/schwab.py
+++ b/bankroll/brokers/schwab.py
@@ -112,7 +112,7 @@ def padToLength(seq: Sequence[_T], length: int, padding: _T) -> Iterable[_T]:
     return chain(seq, [padding] * (length - len(seq)))
 
 
-def parsePositions(path: Path, lenient: bool = False) -> Sequence[Position]:
+def _parsePositions(path: Path, lenient: bool = False) -> Sequence[Position]:
     with open(path, newline='') as csvfile:
         reader = csv.reader(csvfile)
 
@@ -269,7 +269,7 @@ def _parseSchwabTransaction(
 
 
 # Transactions will be ordered from oldest to newest
-def parseTransactions(path: Path, lenient: bool = False) -> List[Activity]:
+def _parseTransactions(path: Path, lenient: bool = False) -> List[Activity]:
     with open(path, newline='') as csvfile:
         reader = csv.reader(csvfile)
 
@@ -369,7 +369,7 @@ class SchwabAccount(AccountData):
             return []
 
         if not self._positions:
-            self._positions = parsePositions(self._positionsPath,
+            self._positions = _parsePositions(self._positionsPath,
                                              lenient=self._lenient)
 
         return self._positions
@@ -379,7 +379,7 @@ class SchwabAccount(AccountData):
             return []
 
         if not self._activity:
-            self._activity = parseTransactions(self._transactionsPath,
+            self._activity = _parseTransactions(self._transactionsPath,
                                                lenient=self._lenient)
 
         return self._activity

--- a/bankroll/brokers/vanguard.py
+++ b/bankroll/brokers/vanguard.py
@@ -211,7 +211,7 @@ def _parseTransactions(path: Path, lenient: bool = False) -> List[Activity]:
 
 
 class VanguardAccount(AccountData):
-    _positionsAndActivity: Optional[PositionsAndActivity]
+    _positionsAndActivity: Optional[PositionsAndActivity] = None
 
     @classmethod
     def fromSettings(cls, settings: Mapping[configuration.Settings, str],

--- a/bankroll/brokers/vanguard.py
+++ b/bankroll/brokers/vanguard.py
@@ -7,7 +7,7 @@ from datetime import datetime
 from decimal import Decimal
 from enum import unique
 from pathlib import Path
-from typing import Dict, Iterable, List, NamedTuple, Optional, Sequence, Set, Tuple
+from typing import Dict, Iterable, List, Mapping, NamedTuple, Optional, Sequence, Set, Tuple
 
 import bankroll.configuration as configuration
 import csv
@@ -212,6 +212,14 @@ def _parseTransactions(path: Path, lenient: bool = False) -> List[Activity]:
 
 class VanguardAccount(AccountData):
     _positionsAndActivity: Optional[PositionsAndActivity]
+
+    @classmethod
+    def fromSettings(cls, settings: Mapping[configuration.Settings, str],
+                     lenient: bool) -> 'VanguardAccount':
+        statement = settings.get(Settings.STATEMENT)
+
+        return cls(statement=Path(statement) if statement else None,
+                   lenient=lenient)
 
     def __init__(self, statement: Optional[Path] = None,
                  lenient: bool = False):

--- a/bankroll/brokers/vanguard.py
+++ b/bankroll/brokers/vanguard.py
@@ -107,8 +107,8 @@ def _parsePositions(path: Path,
                          lenient=lenient))
 
 
-def parsePositionsAndActivity(path: Path,
-                              lenient: bool = False) -> PositionsAndActivity:
+def _parsePositionsAndActivity(path: Path,
+                               lenient: bool = False) -> PositionsAndActivity:
     activity = _parseTransactions(path, lenient=lenient)
     positions = _parsePositions(path, activity=activity, lenient=lenient)
     return PositionsAndActivity(positions, activity)
@@ -232,7 +232,7 @@ class VanguardAccount(AccountData):
             return None
 
         if not self._positionsAndActivity:
-            self._positionsAndActivity = parsePositionsAndActivity(
+            self._positionsAndActivity = _parsePositionsAndActivity(
                 self._statement, lenient=self._lenient)
 
         return self._positionsAndActivity

--- a/bankroll/model/__init__.py
+++ b/bankroll/model/__init__.py
@@ -1,3 +1,4 @@
+from .account import AccountData
 from .activity import Activity, CashPayment, Trade, TradeFlags
 from .cash import Currency, Cash
 from .instrument import Instrument, Stock, Bond, Option, OptionType, FutureOption, Future, Forex

--- a/bankroll/model/account.py
+++ b/bankroll/model/account.py
@@ -18,8 +18,8 @@ class AccountData(ABC):
     # like this, instead of an unintuitive mapping.
     #
     # TODO: Hoist `lenient` into a Setting to make this less awkward.
-    @abstractmethod
     @classmethod
+    @abstractmethod
     def fromSettings(cls, settings: Mapping[Settings, str],
                      lenient: bool) -> 'AccountData':
         pass

--- a/bankroll/model/account.py
+++ b/bankroll/model/account.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+from typing import Iterable, Optional
+
+from .activity import Activity
+from .marketdata import MarketDataProvider
+from .position import Position
+
+
+# Offers data about one or more brokerage accounts, initialized with data
+# (e.g., exported files) or a mechanism to get the data (e.g., a live
+# connection).
+class AccountData(ABC):
+    # Returns the positions currently held, fetching the data on-demand if
+    # necessary.
+    #
+    # Subclasses are encouraged to memoize this result.
+    @abstractmethod
+    def positions(self) -> Iterable[Position]:
+        pass
+
+    # Returns historical account activity, loading it if necessary.
+    #
+    # Subclasses are encouraged to memoize this result.
+    @abstractmethod
+    def activity(self) -> Iterable[Activity]:
+        pass
+
+    @property
+    def marketDataProvider(self) -> Optional[MarketDataProvider]:
+        return None

--- a/bankroll/model/account.py
+++ b/bankroll/model/account.py
@@ -1,5 +1,6 @@
 from abc import ABC, abstractmethod
-from typing import Iterable, Optional
+from bankroll.configuration import Settings
+from typing import Iterable, Mapping, Optional
 
 from .activity import Activity
 from .marketdata import MarketDataProvider
@@ -10,6 +11,19 @@ from .position import Position
 # (e.g., exported files) or a mechanism to get the data (e.g., a live
 # connection).
 class AccountData(ABC):
+    # Instantiates the receiving type using the information in the given
+    # settings map.
+    #
+    # TODO: Refactor/simplify Configuration class so it can be used in cases
+    # like this, instead of an unintuitive mapping.
+    #
+    # TODO: Hoist `lenient` into a Setting to make this less awkward.
+    @abstractmethod
+    @classmethod
+    def fromSettings(cls, settings: Mapping[Settings, str],
+                     lenient: bool) -> 'AccountData':
+        pass
+
     # Returns the positions currently held, fetching the data on-demand if
     # necessary.
     #

--- a/notebooks/Portfolio-Returns.ipynb
+++ b/notebooks/Portfolio-Returns.ipynb
@@ -22,20 +22,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "positions: List[Position] = []\n",
-    "trades: List[Trade] = []"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "util.startLoop()\n",
     "\n",
-    "data = AccountAggregator(AccountAggregator.allSettings()).loadData(lenient=False)\n",
-    "assert data.dataProvider"
+    "accounts = AccountAggregator.fromSettings(AccountAggregator.allSettings(), lenient=False)\n",
+    "assert accounts.marketDataProvider"
    ]
   },
   {
@@ -44,7 +34,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "frame = positions_to_dataframe(data.positions)"
+    "frame = positions_to_dataframe(accounts.positions())"
    ]
   },
   {
@@ -53,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "positions, frame, historical_data = positions_to_history(data.dataProvider, data.positions, frame)"
+    "positions, frame, historical_data = positions_to_history(accounts.marketDataProvider, accounts.positions(), frame)"
    ]
   },
   {
@@ -73,7 +63,7 @@
    },
    "outputs": [],
    "source": [
-    "returns = positions_to_returns(data.dataProvider, positions, 'America/New_York')"
+    "returns = positions_to_returns(accounts.marketDataProvider, positions, 'America/New_York')"
    ]
   },
   {

--- a/notebooks/Portfolio-Returns.ipynb
+++ b/notebooks/Portfolio-Returns.ipynb
@@ -34,7 +34,7 @@
    "source": [
     "util.startLoop()\n",
     "\n",
-    "data = DataAggregator(DataAggregator.allSettings()).loadData(lenient=False)\n",
+    "data = AccountAggregator(AccountAggregator.allSettings()).loadData(lenient=False)\n",
     "assert data.dataProvider"
    ]
   },

--- a/notebooks/Portfolio.ipynb
+++ b/notebooks/Portfolio.ipynb
@@ -23,7 +23,7 @@
    "source": [
     "util.startLoop()\n",
     "\n",
-    "data = DataAggregator(DataAggregator.allSettings()).loadData(lenient=False)\n",
+    "data = AccountAggregator(AccountAggregator.allSettings()).loadData(lenient=False)\n",
     "assert data.dataProvider"
    ]
   },

--- a/notebooks/Portfolio.ipynb
+++ b/notebooks/Portfolio.ipynb
@@ -23,8 +23,8 @@
    "source": [
     "util.startLoop()\n",
     "\n",
-    "data = AccountAggregator(AccountAggregator.allSettings()).loadData(lenient=False)\n",
-    "assert data.dataProvider"
+    "accounts = AccountAggregator.fromSettings(AccountAggregator.allSettings(), lenient=False)\n",
+    "assert accounts.marketDataProvider"
    ]
   },
   {
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stockPositions = [p for p in data.positions if isinstance(p.instrument, Stock)]\n",
+    "stockPositions = [p for p in accounts.positions() if isinstance(p.instrument, Stock)]\n",
     "stockPositions.sort(key=lambda p: p.instrument)"
    ]
   },
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "values = liveValuesForPositions(stockPositions, data.dataProvider)\n",
+    "values = liveValuesForPositions(stockPositions, accounts.marketDataProvider)\n",
     "for p in stockPositions:\n",
     "    if p in values:\n",
     "        continue\n",
@@ -58,7 +58,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "realizedBases = {p: realizedBasisForSymbol(p.instrument.symbol, data.activity) for p in stockPositions}"
+    "realizedBases = {p: realizedBasisForSymbol(p.instrument.symbol, accounts.activity()) for p in stockPositions}"
    ]
   },
   {

--- a/notebooks/Portfolio.ipynb
+++ b/notebooks/Portfolio.ipynb
@@ -33,7 +33,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stockPositions = [p for p in accounts.positions() if isinstance(p.instrument, Stock)]\n",
+    "stockPositions = [p for p in accounts.positions() if isinstance(p.instrument, Stock) and p.quantity != 0]\n",
     "stockPositions.sort(key=lambda p: p.instrument)"
    ]
   },

--- a/notebooks/Rebalance.ipynb
+++ b/notebooks/Rebalance.ipynb
@@ -33,8 +33,8 @@
    "source": [
     "util.startLoop()\n",
     "\n",
-    "data = AccountAggregator(AccountAggregator.allSettings()).loadData(lenient=False)\n",
-    "assert data.dataProvider"
+    "accounts = AccountAggregator.fromSettings(AccountAggregator.allSettings(), lenient=False)\n",
+    "assert accounts.marketDataProvider"
    ]
   },
   {
@@ -43,7 +43,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "stockPositions = [p for p in data.positions if isinstance(p.instrument, Stock)]\n",
+    "stockPositions = [p for p in accounts.positions() if isinstance(p.instrument, Stock)]\n",
     "stockPositions.sort(key=lambda p: p.instrument)"
    ]
   },
@@ -53,7 +53,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "values = liveValuesForPositions(stockPositions, data.dataProvider)"
+    "values = liveValuesForPositions(stockPositions, accounts.marketDataProvider)"
    ]
   },
   {

--- a/notebooks/Rebalance.ipynb
+++ b/notebooks/Rebalance.ipynb
@@ -33,7 +33,7 @@
    "source": [
     "util.startLoop()\n",
     "\n",
-    "data = DataAggregator(DataAggregator.allSettings()).loadData(lenient=False)\n",
+    "data = AccountAggregator(AccountAggregator.allSettings()).loadData(lenient=False)\n",
     "assert data.dataProvider"
    ]
   },

--- a/script/typecheck
+++ b/script/typecheck
@@ -6,4 +6,4 @@ set -o pipefail
 # shellcheck disable=SC1091
 . venv/bin/activate
 
-python -m unittest discover -s tests -v
+mypy --strict --ignore-missing-imports -p bankroll

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setup(
     name='bankroll',
-    version='0.2.1',
+    version='0.3.0',
     author='Justin Spahr-Summers',
     author_email='justin@jspahrsummers.com',
     description=

--- a/tests/helpers.py
+++ b/tests/helpers.py
@@ -1,7 +1,8 @@
 from datetime import date, datetime
 from decimal import Decimal
 from hypothesis.strategies import builds, dates, datetimes, decimals, from_regex, from_type, just, lists, integers, none, one_of, register_type_strategy, sampled_from, text, SearchStrategy
-from bankroll import Activity, Cash, Currency, Instrument, Stock, Bond, Option, OptionType, FutureOption, Future, Forex, Position, CashPayment, Trade, TradeFlags, Quote
+from bankroll import AccountData, Activity, Cash, Currency, Instrument, Stock, Bond, Option, OptionType, FutureOption, Future, Forex, Position, CashPayment, Trade, TradeFlags, Quote
+from bankroll.brokers import *
 from bankroll.configuration import Settings
 from typing import List, Optional, TypeVar
 
@@ -247,6 +248,22 @@ register_type_strategy(Quote, uniformCurrencyQuotes())
 
 register_type_strategy(
     Settings, one_of([from_type(s) for s in Settings.__subclasses__()]))
+
+fixtureSettings = {
+    fidelity.Settings.POSITIONS: 'tests/fidelity_positions.csv',
+    fidelity.Settings.TRANSACTIONS: 'tests/fidelity_transactions.csv',
+    ibkr.Settings.ACTIVITY: 'tests/ibkr_activity.xml',
+    ibkr.Settings.TRADES: 'tests/ibkr_trades.xml',
+    schwab.Settings.POSITIONS: 'tests/schwab_positions.CSV',
+    schwab.Settings.TRANSACTIONS: 'tests/schwab_transactions.CSV',
+    vanguard.Settings.STATEMENT:
+    'tests/vanguard_positions_and_transactions.csv',
+}
+
+register_type_strategy(
+    AccountData,
+    sampled_from(AccountData.__subclasses__()).map(
+        lambda cls: cls.fromSettings(fixtureSettings, lenient=False)))
 
 
 def cashUSD(amount: Decimal) -> Cash:

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -8,24 +8,9 @@ import unittest
 
 
 class TestAccountAggregator(unittest.TestCase):
-    def setUp(self) -> None:
-        self.settings = {
-            fidelity.Settings.POSITIONS:
-            'tests/fidelity_positions.csv',
-            fidelity.Settings.TRANSACTIONS:
-            'tests/fidelity_transactions.csv',
-            ibkr.Settings.ACTIVITY:
-            'tests/ibkr_activity.xml',
-            ibkr.Settings.TRADES:
-            'tests/ibkr_trades.xml',
-            schwab.Settings.POSITIONS:
-            'tests/schwab_positions.CSV',
-            schwab.Settings.TRANSACTIONS:
-            'tests/schwab_transactions.CSV',
-            vanguard.Settings.STATEMENT:
-            'tests/vanguard_positions_and_transactions.csv',
-        }
+    settings = helpers.fixtureSettings
 
+    def setUp(self) -> None:
         # Tests that keys do not clobber each other.
         self.assertEqual(len(self.settings), 7)
 

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -29,37 +29,31 @@ class TestAccountAggregator(unittest.TestCase):
         # Tests that keys do not clobber each other.
         self.assertEqual(len(self.settings), 7)
 
-        self.data = AccountAggregator(self.settings)
-
-    def testValuesStartEmpty(self) -> None:
-        self.assertEqual(self.data.positions, [])
-        self.assertEqual(self.data.activity, [])
-        self.assertIsNone(self.data.dataProvider)
+        self.data = AccountAggregator.fromSettings(self.settings,
+                                                   lenient=False)
 
     def testLoadData(self) -> None:
-        self.data.loadData(lenient=False)
-
-        instruments = set((p.instrument for p in self.data.positions))
+        instruments = set((p.instrument for p in self.data.positions()))
 
         for p in fidelity.parsePositions(
                 Path(self.settings[fidelity.Settings.POSITIONS])):
             self.assertIn(p.instrument, instruments)
         for a in fidelity.parseTransactions(
                 Path(self.settings[fidelity.Settings.TRANSACTIONS])):
-            self.assertIn(a, self.data.activity)
+            self.assertIn(a, self.data.activity())
 
         for p in schwab.parsePositions(
                 Path(self.settings[schwab.Settings.POSITIONS])):
             self.assertIn(p.instrument, instruments)
         for a in schwab.parseTransactions(
                 Path(self.settings[schwab.Settings.TRANSACTIONS])):
-            self.assertIn(a, self.data.activity)
+            self.assertIn(a, self.data.activity())
 
         for a in ibkr.parseTrades(Path(self.settings[ibkr.Settings.TRADES])):
-            self.assertIn(a, self.data.activity)
+            self.assertIn(a, self.data.activity())
         for a in ibkr.parseNonTradeActivity(
                 Path(self.settings[ibkr.Settings.ACTIVITY])):
-            self.assertIn(a, self.data.activity)
+            self.assertIn(a, self.data.activity())
 
         vanguardData = vanguard.parsePositionsAndActivity(
             Path(self.settings[vanguard.Settings.STATEMENT]))
@@ -67,4 +61,4 @@ class TestAccountAggregator(unittest.TestCase):
         for p in vanguardData.positions:
             self.assertIn(p.instrument, instruments)
         for a in vanguardData.activity:
-            self.assertIn(a, self.data.activity)
+            self.assertIn(a, self.data.activity())

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -1,4 +1,4 @@
-from bankroll.aggregator import DataAggregator
+from bankroll.aggregator import AccountAggregator
 from bankroll.brokers import *
 from bankroll.configuration import Settings
 from pathlib import Path
@@ -7,7 +7,7 @@ import helpers
 import unittest
 
 
-class TestDataAggregator(unittest.TestCase):
+class TestAccountAggregator(unittest.TestCase):
     def setUp(self) -> None:
         self.settings = {
             fidelity.Settings.POSITIONS:
@@ -29,7 +29,7 @@ class TestDataAggregator(unittest.TestCase):
         # Tests that keys do not clobber each other.
         self.assertEqual(len(self.settings), 7)
 
-        self.data = DataAggregator(self.settings)
+        self.data = AccountAggregator(self.settings)
 
     def testValuesStartEmpty(self) -> None:
         self.assertEqual(self.data.positions, [])

--- a/tests/test_aggregator.py
+++ b/tests/test_aggregator.py
@@ -35,30 +35,31 @@ class TestAccountAggregator(unittest.TestCase):
     def testLoadData(self) -> None:
         instruments = set((p.instrument for p in self.data.positions()))
 
-        for p in fidelity.parsePositions(
-                Path(self.settings[fidelity.Settings.POSITIONS])):
+        fidelityAccount = fidelity.FidelityAccount(
+            positions=Path(self.settings[fidelity.Settings.POSITIONS]),
+            transactions=Path(self.settings[fidelity.Settings.TRANSACTIONS]))
+        for p in fidelityAccount.positions():
             self.assertIn(p.instrument, instruments)
-        for a in fidelity.parseTransactions(
-                Path(self.settings[fidelity.Settings.TRANSACTIONS])):
+        for a in fidelityAccount.activity():
             self.assertIn(a, self.data.activity())
 
-        for p in schwab.parsePositions(
-                Path(self.settings[schwab.Settings.POSITIONS])):
+        schwabAccount = schwab.SchwabAccount(
+            positions=Path(self.settings[schwab.Settings.POSITIONS]),
+            transactions=Path(self.settings[schwab.Settings.TRANSACTIONS]))
+        for p in schwabAccount.positions():
             self.assertIn(p.instrument, instruments)
-        for a in schwab.parseTransactions(
-                Path(self.settings[schwab.Settings.TRANSACTIONS])):
+        for a in schwabAccount.activity():
             self.assertIn(a, self.data.activity())
 
-        for a in ibkr.parseTrades(Path(self.settings[ibkr.Settings.TRADES])):
-            self.assertIn(a, self.data.activity())
-        for a in ibkr.parseNonTradeActivity(
-                Path(self.settings[ibkr.Settings.ACTIVITY])):
+        ibAccount = ibkr.IBAccount(
+            trades=Path(self.settings[ibkr.Settings.TRADES]),
+            activity=Path(self.settings[ibkr.Settings.ACTIVITY]))
+        for a in ibAccount.activity():
             self.assertIn(a, self.data.activity())
 
-        vanguardData = vanguard.parsePositionsAndActivity(
-            Path(self.settings[vanguard.Settings.STATEMENT]))
-
-        for p in vanguardData.positions:
+        vanguardAccount = vanguard.VanguardAccount(
+            statement=Path(self.settings[vanguard.Settings.STATEMENT]))
+        for p in vanguardAccount.positions():
             self.assertIn(p.instrument, instruments)
-        for a in vanguardData.activity:
+        for a in vanguardAccount.activity():
             self.assertIn(a, self.data.activity())

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -47,6 +47,10 @@ class TestConfiguration(unittest.TestCase):
         vanguardSettings = self.config.section(vanguard.Settings)
         self.assertIsNone(vanguardSettings.get(vanguard.Settings.STATEMENT))
 
+    def testNamespacedSettingsDoNotClobberEachOther(self) -> None:
+        # Tests that settings keys do not clobber each other.
+        self.assertEqual(len(helpers.fixtureSettings), 7)
+
     # Verifies that settings keys are present in bankroll.default.ini, even if commented out.
     @given(from_type(Settings))
     def testSettingsListedInDefaultINI(self, key: Settings) -> None:

--- a/tests/test_fidelity.py
+++ b/tests/test_fidelity.py
@@ -11,8 +11,9 @@ import unittest
 
 class TestFidelityPositions(unittest.TestCase):
     def setUp(self) -> None:
-        self.positions = fidelity.parsePositions(
-            Path('tests/fidelity_positions.csv'))
+        self.positions = list(
+            fidelity.FidelityAccount(
+                positions=Path('tests/fidelity_positions.csv')).positions())
         self.positions.sort(key=lambda p: p.instrument)
 
     def test_positionValidity(self) -> None:
@@ -76,8 +77,9 @@ class TestFidelityPositions(unittest.TestCase):
 
 class TestFidelityTransactions(unittest.TestCase):
     def setUp(self) -> None:
-        self.activity = fidelity.parseTransactions(
-            Path('tests/fidelity_transactions.csv'))
+        self.activity = list(
+            fidelity.FidelityAccount(transactions=Path(
+                'tests/fidelity_transactions.csv')).activity())
         self.activity.sort(key=lambda t: t.date)
 
         self.activityByDate = {

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -15,7 +15,8 @@ import unittest
 
 class TestIBKRTrades(unittest.TestCase):
     def setUp(self) -> None:
-        self.trades = ibkr.parseTrades(Path('tests/ibkr_trades.xml'))
+        self.trades = [t for t in
+            ibkr.IBAccount(trades=Path('tests/ibkr_trades.xml')).activity() if isinstance(t, Trade)]
         self.trades.sort(key=lambda t: t.instrument.symbol)
 
         self.tradesBySymbol = {
@@ -200,8 +201,7 @@ class TestIBKRTrades(unittest.TestCase):
 
 class TestIBKRActivity(unittest.TestCase):
     def setUp(self) -> None:
-        self.activity = ibkr.parseNonTradeActivity(
-            Path('tests/ibkr_activity.xml'))
+        self.activity = list(ibkr.IBAccount(activity=Path('tests/ibkr_activity.xml')).activity())
         self.activity.sort(key=lambda t: t.date)
 
         self.activityByDate = {

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -15,8 +15,11 @@ import unittest
 
 class TestIBKRTrades(unittest.TestCase):
     def setUp(self) -> None:
-        self.trades = [t for t in
-            ibkr.IBAccount(trades=Path('tests/ibkr_trades.xml')).activity() if isinstance(t, Trade)]
+        self.trades = [
+            t for t in ibkr.IBAccount(
+                trades=Path('tests/ibkr_trades.xml')).activity()
+            if isinstance(t, Trade)
+        ]
         self.trades.sort(key=lambda t: t.instrument.symbol)
 
         self.tradesBySymbol = {
@@ -201,7 +204,9 @@ class TestIBKRTrades(unittest.TestCase):
 
 class TestIBKRActivity(unittest.TestCase):
     def setUp(self) -> None:
-        self.activity = list(ibkr.IBAccount(activity=Path('tests/ibkr_activity.xml')).activity())
+        self.activity = list(
+            ibkr.IBAccount(
+                activity=Path('tests/ibkr_activity.xml')).activity())
         self.activity.sort(key=lambda t: t.date)
 
         self.activityByDate = {

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -303,11 +303,11 @@ class TestAccountData(unittest.TestCase):
         assume(not isinstance(account, ibkr.IBAccount))
 
         self.assertNotEqual(list(account.positions()), [])
-    
+
     @given(from_type(AccountData))
     def test_activityLoads(self, account: AccountData) -> None:
         self.assertNotEqual(list(account.activity()), [])
-    
+
     @given(from_type(AccountData))
     def test_dataLoadingIsIdempotent(self, account: AccountData) -> None:
         self.assertEqual(list(account.positions()), list(account.positions()))

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -1,4 +1,5 @@
-from bankroll.model import Cash, Currency, Instrument, Bond, Stock, Option, OptionType, FutureOption, Future, Position, Quote, Trade
+from bankroll.brokers import ibkr
+from bankroll.model import AccountData, Cash, Currency, Instrument, Bond, Stock, Option, OptionType, FutureOption, Future, Position, Quote, Trade
 from datetime import date
 from decimal import Decimal, ROUND_UP
 from hypothesis import assume, given, reproduce_failure
@@ -292,6 +293,25 @@ class TestTrade(unittest.TestCase):
                     0,
                     msg='Sell transaction for loss should have a negative price'
                 )
+
+
+class TestAccountData(unittest.TestCase):
+    @given(from_type(AccountData))
+    def test_positionsLoad(self, account: AccountData) -> None:
+        # IB position loading requires a live data connection, which we won't
+        # have in test.
+        assume(not isinstance(account, ibkr.IBAccount))
+
+        self.assertNotEqual(list(account.positions()), [])
+    
+    @given(from_type(AccountData))
+    def test_activityLoads(self, account: AccountData) -> None:
+        self.assertNotEqual(list(account.activity()), [])
+    
+    @given(from_type(AccountData))
+    def test_dataLoadingIsIdempotent(self, account: AccountData) -> None:
+        self.assertEqual(list(account.positions()), list(account.positions()))
+        self.assertEqual(list(account.activity()), list(account.activity()))
 
 
 if __name__ == '__main__':

--- a/tests/test_schwab.py
+++ b/tests/test_schwab.py
@@ -12,7 +12,8 @@ import unittest
 class TestSchwabPositions(unittest.TestCase):
     def setUp(self) -> None:
         self.positions = list(
-            schwab.parsePositions(Path('tests/schwab_positions.CSV')))
+            schwab.SchwabAccount(
+                positions=Path('tests/schwab_positions.CSV')).positions())
         self.positions.sort(key=lambda p: p.instrument.symbol)
 
     def test_positionValidity(self) -> None:
@@ -50,7 +51,8 @@ class TestSchwabPositions(unittest.TestCase):
 class TestSchwabTransactions(unittest.TestCase):
     def setUp(self) -> None:
         self.activity = list(
-            schwab.parseTransactions(Path('tests/schwab_transactions.CSV')))
+            schwab.SchwabAccount(
+                transactions=Path('tests/schwab_transactions.CSV')).activity())
         self.activity.sort(key=lambda t: t.date)
 
         self.activityByDate = {

--- a/tests/test_vanguard.py
+++ b/tests/test_vanguard.py
@@ -11,8 +11,9 @@ import unittest
 
 class TestVanguardPositions(unittest.TestCase):
     def setUp(self) -> None:
-        self.positions = vanguard.parsePositionsAndActivity(
-            Path('tests/vanguard_positions_and_transactions.csv')).positions
+        self.positions = list(
+            vanguard.VanguardAccount(statement=Path(
+                'tests/vanguard_positions_and_transactions.csv')).positions())
         self.positions.sort(key=lambda p: p.instrument.symbol)
 
     def test_positionValidity(self) -> None:
@@ -61,8 +62,9 @@ class TestVanguardPositions(unittest.TestCase):
 
 class TestVanguardTransactions(unittest.TestCase):
     def setUp(self) -> None:
-        self.activity = vanguard.parsePositionsAndActivity(
-            Path('tests/vanguard_positions_and_transactions.csv')).activity
+        self.activity = list(
+            vanguard.VanguardAccount(statement=Path(
+                'tests/vanguard_positions_and_transactions.csv')).activity())
         self.activity.sort(key=lambda t: t.date)
 
         self.activityByDate = {


### PR DESCRIPTION
Resolves #64.

- [x] Vanguard
- [x] Fidelity
- [x] Add convenience constructors which accept `Settings` and convert to broker interfaces?
- [x] Remove/hide old ways of doing things, and update tests
- [x] ~~Make `lenient` into a setting~~
- [x] ~~Simplify passing/aggregation of settings (e.g., reusing `Configuration` class if possible)~~
- [x] Write tests, defining type strategies for each broker interface
- [x] Simplify `DataAggregator` and/or turn into a subclass of `AccountData`
- [x] Automatically discover brokerage `AccountData` implementations in `DataAggregator`
- [x] Expand CONTRIBUTING (or other documentation) to explain how to integrate a new broker