### PR TITLE
Save instrument's originating exchange, when available

### DIFF
--- a/bankroll/analysis.py
+++ b/bankroll/analysis.py
@@ -26,7 +26,8 @@ def normalizeSymbol(symbol: str) -> str:
 def normalizeInstrument(instrument: Instrument) -> Instrument:
     if isinstance(instrument, Stock):
         return Stock(symbol=normalizeSymbol(instrument.symbol),
-                     currency=instrument.currency)
+                     currency=instrument.currency,
+                     exchange=instrument.exchange)
     elif isinstance(instrument, Option):
         # Handles the FutureOption subclass correctly as well.
         return replace(instrument,

--- a/bankroll/brokers/ibkr.py
+++ b/bankroll/brokers/ibkr.py
@@ -638,14 +638,15 @@ def _downloadBalance(ib: IB.IB, lenient: bool) -> AccountBalance:
 
 
 def _stockContract(stock: Stock) -> IB.Contract:
-    return IB.Stock(symbol=stock.symbol,
-                    exchange='SMART',
-                    currency=stock.currency.name)
+    return IB.Stock(
+        symbol=stock.symbol,
+        exchange=f'SMART:{stock.exchange}' if stock.exchange else 'SMART',
+        currency=stock.currency.name)
 
 
 def _bondContract(bond: Bond) -> IB.Contract:
     return IB.Bond(symbol=bond.symbol,
-                   exchange='SMART',
+                   exchange=bond.exchange or 'SMART',
                    currency=bond.currency.name)
 
 
@@ -654,7 +655,7 @@ def _optionContract(option: Option,
     lastTradeDate = option.expiration.strftime('%Y%m%d')
 
     return cls(localSymbol=option.symbol,
-               exchange='SMART',
+               exchange=option.exchange or 'SMART',
                currency=option.currency.name,
                lastTradeDateOrContractMonth=lastTradeDate,
                right=option.optionType.value,
@@ -665,15 +666,19 @@ def _optionContract(option: Option,
 def _futuresContract(future: Future) -> IB.Contract:
     lastTradeDate = future.expiration.strftime('%Y%m%d')
 
-    return IB.Future(symbol=future.symbol,
-                     exchange='SMART',
-                     currency=future.currency.name,
-                     multiplier=str(future.multiplier),
-                     lastTradeDateOrContractMonth=lastTradeDate)
+    return IB.Future(
+        symbol=future.symbol,
+        # I don't think futures even _have_ smart routing, but we can try...
+        exchange=future.exchange or 'SMART',
+        currency=future.currency.name,
+        multiplier=str(future.multiplier),
+        lastTradeDateOrContractMonth=lastTradeDate)
 
 
 def _forexContract(forex: Forex) -> IB.Contract:
-    return IB.Forex(pair=forex.symbol, currency=forex.currency.name)
+    return IB.Forex(pair=forex.symbol,
+                    currency=forex.currency.name,
+                    exchange=forex.exchange or 'SMART')
 
 
 def _contract(instrument: Instrument) -> IB.Contract:

--- a/bankroll/brokers/ibkr.py
+++ b/bankroll/brokers/ibkr.py
@@ -682,9 +682,10 @@ def _bondContract(bond: Bond) -> IB.Contract:
 def _optionContract(option: Option,
                     cls: Type[IB.Contract] = IB.Option) -> IB.Contract:
     lastTradeDate = option.expiration.strftime('%Y%m%d')
+    defaultExchange = '' if issubclass(cls, IB.FuturesOption) else 'SMART'
 
     return cls(localSymbol=option.symbol,
-               exchange=option.exchange or 'SMART',
+               exchange=option.exchange or defaultExchange,
                currency=option.currency.name,
                lastTradeDateOrContractMonth=lastTradeDate,
                right=option.optionType.value,
@@ -695,13 +696,11 @@ def _optionContract(option: Option,
 def _futuresContract(future: Future) -> IB.Contract:
     lastTradeDate = future.expiration.strftime('%Y%m%d')
 
-    return IB.Future(
-        symbol=future.symbol,
-        # I don't think futures even _have_ smart routing, but we can try...
-        exchange=future.exchange or 'SMART',
-        currency=future.currency.name,
-        multiplier=str(future.multiplier),
-        lastTradeDateOrContractMonth=lastTradeDate)
+    return IB.Future(symbol=future.symbol,
+                     exchange=future.exchange or '',
+                     currency=future.currency.name,
+                     multiplier=str(future.multiplier),
+                     lastTradeDateOrContractMonth=lastTradeDate)
 
 
 def _forexContract(forex: Forex) -> IB.Contract:

--- a/bankroll/brokers/ibkr.py
+++ b/bankroll/brokers/ibkr.py
@@ -55,6 +55,7 @@ def _parseFiniteDecimal(input: str) -> Decimal:
 def _parseOption(symbol: str,
                  currency: Currency,
                  multiplier: Decimal,
+                 exchange: Optional[str],
                  cls: Type[Option] = Option) -> Option:
     # https://en.wikipedia.org/wiki/Option_symbol#The_OCC_Option_Symbol
     match = re.match(
@@ -72,10 +73,12 @@ def _parseOption(symbol: str,
                currency=currency,
                optionType=optionType,
                expiration=datetime.strptime(match['date'], '%y%m%d').date(),
-               strike=_parseFiniteDecimal(match['strike']) / 1000)
+               strike=_parseFiniteDecimal(match['strike']) / 1000,
+               exchange=exchange)
 
 
-def _parseForex(symbol: str, currency: Currency) -> Forex:
+def _parseForex(symbol: str, currency: Currency,
+                exchange: Optional[str]) -> Forex:
     match = re.match(r'^(?P<base>[A-Z]{3})\.(?P<quote>[A-Z]{3})', symbol)
     if not match:
         raise ValueError(f'Could not parse IB cash symbol: {symbol}')
@@ -87,11 +90,13 @@ def _parseForex(symbol: str, currency: Currency) -> Forex:
             f'Expected quote currency {quoteCurrency} to match position currency {currency}'
         )
 
-    return Forex(baseCurrency=baseCurrency, quoteCurrency=quoteCurrency)
+    return Forex(baseCurrency=baseCurrency,
+                 quoteCurrency=quoteCurrency,
+                 exchange=exchange)
 
 
-def _parseFutureOptionContract(contract: IB.Contract,
-                               currency: Currency) -> Instrument:
+def _parseFutureOptionContract(contract: IB.Contract, currency: Currency,
+                               exchange: Optional[str]) -> Instrument:
     if contract.right.startswith('C'):
         optionType = OptionType.CALL
     elif contract.right.startswith('P'):
@@ -106,7 +111,8 @@ def _parseFutureOptionContract(contract: IB.Contract,
                         expiration=_parseIBDate(
                             contract.lastTradeDateOrContractMonth).date(),
                         strike=_parseFiniteDecimal(contract.strike),
-                        multiplier=_parseFiniteDecimal(contract.multiplier))
+                        multiplier=_parseFiniteDecimal(contract.multiplier),
+                        exchange=exchange)
 
 
 def _extractPosition(p: IB.Position) -> Position:
@@ -117,32 +123,41 @@ def _extractPosition(p: IB.Position) -> Position:
         raise ValueError(f'Unrecognized currency in position: {p}')
 
     currency = Currency[p.contract.currency]
+    exchange = p.contract.exchange or None
 
     try:
         instrument: Instrument
         if tag == 'STK':
-            instrument = Stock(symbol=symbol, currency=currency)
+            instrument = Stock(symbol=symbol,
+                               currency=currency,
+                               exchange=exchange)
         elif tag == 'BILL' or tag == 'BOND':
             instrument = Bond(symbol=symbol,
                               currency=currency,
-                              validateSymbol=False)
+                              validateSymbol=False,
+                              exchange=exchange)
         elif tag == 'OPT':
             instrument = _parseOption(symbol=symbol,
                                       currency=currency,
                                       multiplier=_parseFiniteDecimal(
-                                          p.contract.multiplier))
+                                          p.contract.multiplier),
+                                      exchange=exchange)
         elif tag == 'FUT':
             instrument = Future(
                 symbol=symbol,
                 currency=currency,
                 multiplier=_parseFiniteDecimal(p.contract.multiplier),
                 expiration=_parseIBDate(
-                    p.contract.lastTradeDateOrContractMonth).date())
+                    p.contract.lastTradeDateOrContractMonth).date(),
+                exchange=exchange)
         elif tag == 'FOP':
             instrument = _parseFutureOptionContract(p.contract,
-                                                    currency=currency)
+                                                    currency=currency,
+                                                    exchange=exchange)
         elif tag == 'CASH':
-            instrument = _parseForex(symbol=symbol, currency=currency)
+            instrument = _parseForex(symbol=symbol,
+                                     currency=currency,
+                                     exchange=exchange)
         else:
             raise ValueError(
                 f'Unrecognized/unsupported security type in position: {p}')
@@ -338,7 +353,8 @@ _instrumentEntryTypes = Union[_IBTradeConfirm, _IBChangeInDividendAccrual,
                               _IBSLBFee]
 
 
-def _parseFutureOption(entry: _instrumentEntryTypes) -> Instrument:
+def _parseFutureOption(entry: _instrumentEntryTypes,
+                       exchange: Optional[str]) -> Instrument:
     if entry.putCall == 'C':
         optionType = OptionType.CALL
     elif entry.putCall == 'P':
@@ -352,7 +368,8 @@ def _parseFutureOption(entry: _instrumentEntryTypes) -> Instrument:
                         optionType=optionType,
                         expiration=_parseIBDate(entry.expiry).date(),
                         strike=_parseFiniteDecimal(entry.strike),
-                        multiplier=_parseFiniteDecimal(entry.multiplier))
+                        multiplier=_parseFiniteDecimal(entry.multiplier),
+                        exchange=exchange)
 
 
 def _parseInstrument(entry: _instrumentEntryTypes) -> Instrument:
@@ -365,24 +382,36 @@ def _parseInstrument(entry: _instrumentEntryTypes) -> Instrument:
 
     currency = Currency[entry.currency]
 
+    if isinstance(entry, _IBChangeInDividendAccrual):
+        exchange = None
+    else:
+        exchange = entry.exchange
+
+    exchange = exchange or entry.listingExchange or None
+
     tag = entry.assetCategory
     if tag == 'STK':
-        return Stock(symbol=symbol, currency=currency)
+        return Stock(symbol=symbol, currency=currency, exchange=exchange)
     elif tag == 'BILL' or tag == 'BOND':
-        return Bond(symbol=symbol, currency=currency, validateSymbol=False)
+        return Bond(symbol=symbol,
+                    currency=currency,
+                    validateSymbol=False,
+                    exchange=exchange)
     elif tag == 'OPT':
         return _parseOption(symbol=symbol,
                             currency=currency,
-                            multiplier=_parseFiniteDecimal(entry.multiplier))
+                            multiplier=_parseFiniteDecimal(entry.multiplier),
+                            exchange=exchange)
     elif tag == 'FUT':
         return Future(symbol=symbol,
                       currency=currency,
                       multiplier=_parseFiniteDecimal(entry.multiplier),
-                      expiration=_parseIBDate(entry.expiry).date())
+                      expiration=_parseIBDate(entry.expiry).date(),
+                      exchange=exchange)
     elif tag == 'CASH':
-        return _parseForex(symbol=symbol, currency=currency)
+        return _parseForex(symbol=symbol, currency=currency, exchange=exchange)
     elif tag == 'FOP':
-        return _parseFutureOption(entry)
+        return _parseFutureOption(entry, exchange=exchange)
     else:
         raise ValueError(
             f'Unrecognized/unsupported security type in entry: {entry}')

--- a/bankroll/model/instrument.py
+++ b/bankroll/model/instrument.py
@@ -19,6 +19,7 @@ class Instrument(ABC):
     symbol: str
     currency: Currency
     multiplier: Decimal
+    exchange: Optional[str]
 
     @classmethod
     def quantizeMultiplier(cls, multiplier: Decimal) -> Decimal:
@@ -49,10 +50,14 @@ class Instrument(ABC):
 # Also used for ETFs.
 @dataclass(unsafe_hash=True, init=False)
 class Stock(Instrument):
-    def __init__(self, symbol: str, currency: Currency):
+    def __init__(self,
+                 symbol: str,
+                 currency: Currency,
+                 exchange: Optional[str] = None):
         super().__init__(symbol=symbol,
                          currency=currency,
-                         multiplier=Decimal(1))
+                         multiplier=Decimal(1),
+                         exchange=exchange)
 
 
 @dataclass(unsafe_hash=True, init=False)
@@ -66,13 +71,15 @@ class Bond(Instrument):
     def __init__(self,
                  symbol: str,
                  currency: Currency,
+                 exchange: Optional[str] = None,
                  validateSymbol: bool = True):
         if validateSymbol and not self.validBondSymbol(symbol):
             raise ValueError(f'Expected symbol to be a bond CUSIP: {symbol}')
 
         super().__init__(symbol=symbol,
                          currency=currency,
-                         multiplier=Decimal(1))
+                         multiplier=Decimal(1),
+                         exchange=exchange)
 
 
 @unique
@@ -104,6 +111,7 @@ class Option(Instrument):
                  expiration: date,
                  strike: Decimal,
                  multiplier: Decimal = Decimal(100),
+                 exchange: Optional[str] = None,
                  symbol: Optional[str] = None):
         if not underlying:
             raise ValueError('Expected non-empty underlying symbol for Option')
@@ -123,41 +131,57 @@ class Option(Instrument):
 
         super().__init__(symbol=symbol,
                          currency=currency,
-                         multiplier=multiplier)
+                         multiplier=multiplier,
+                         exchange=exchange)
 
 
 @dataclass(unsafe_hash=True, init=False)
 class FutureOption(Option):
-    def __init__(self, symbol: str, underlying: str, currency: Currency,
-                 optionType: OptionType, expiration: date, strike: Decimal,
-                 multiplier: Decimal):
+    def __init__(self,
+                 symbol: str,
+                 underlying: str,
+                 currency: Currency,
+                 optionType: OptionType,
+                 expiration: date,
+                 strike: Decimal,
+                 multiplier: Decimal,
+                 exchange: Optional[str] = None):
         super().__init__(underlying=underlying,
                          currency=currency,
                          optionType=optionType,
                          expiration=expiration,
                          strike=strike,
                          multiplier=multiplier,
-                         symbol=symbol)
+                         symbol=symbol,
+                         exchange=exchange)
 
 
 @dataclass(unsafe_hash=True, init=False)
 class Future(Instrument):
     expiration: date
 
-    def __init__(self, symbol: str, currency: Currency, multiplier: Decimal,
-                 expiration: date):
+    def __init__(self,
+                 symbol: str,
+                 currency: Currency,
+                 multiplier: Decimal,
+                 expiration: date,
+                 exchange: Optional[str] = None):
         self.expiration = expiration
 
         super().__init__(symbol=symbol,
                          currency=currency,
-                         multiplier=multiplier)
+                         multiplier=multiplier,
+                         exchange=exchange)
 
 
 @dataclass(unsafe_hash=True, init=False)
 class Forex(Instrument):
     baseCurrency: Currency
 
-    def __init__(self, baseCurrency: Currency, quoteCurrency: Currency):
+    def __init__(self,
+                 baseCurrency: Currency,
+                 quoteCurrency: Currency,
+                 exchange: Optional[str] = None):
         if baseCurrency == quoteCurrency:
             raise ValueError(
                 f'Forex pair must be composed of different currencies, got {baseCurrency!r} and {quoteCurrency!r}'
@@ -168,7 +192,8 @@ class Forex(Instrument):
         symbol = f'{baseCurrency.name}{quoteCurrency.name}'
         super().__init__(symbol=symbol,
                          currency=quoteCurrency,
-                         multiplier=Decimal(1))
+                         multiplier=Decimal(1),
+                         exchange=exchange)
 
     @property
     def quoteCurrency(self) -> Currency:

--- a/bankroll/model/instrument.py
+++ b/bankroll/model/instrument.py
@@ -34,6 +34,9 @@ class Instrument(ABC):
         if not self.multiplier.is_finite() or self.multiplier <= 0:
             raise ValueError(
                 f'Expected positive multiplier: {self.multiplier}')
+        if self.exchange is not None and len(self.exchange) == 0:
+            raise ValueError(
+                f'If an exchange string is provided, it should be non-empty')
 
         self.multiplier = self.quantizeMultiplier(self.multiplier)
 

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -452,13 +452,6 @@ class TestIBKRParsing(unittest.TestCase):
 
         self.validateTradeContract(tradeConfirm, trade.instrument)
 
-    @unittest.skip('Exists to validate test data only')
-    @given(validTradeConfirms)
-    def test_parsedTradeConfirmConvertsToContract(
-            self, tradeConfirm: ibkr._IBTradeConfirm) -> None:
-        trade = ibkr._parseTradeConfirm(tradeConfirm)
-        self.validateTradeContract(tradeConfirm, trade.instrument)
-
     def validatePositionContract(self, position: IB.Position,
                                  instrument: Instrument) -> None:
         contract = ibkr._contract(instrument)
@@ -489,15 +482,6 @@ class TestIBKRParsing(unittest.TestCase):
         except ValueError:
             return
 
-        self.assertEqual(parsedPosition.quantity,
-                         Position.quantizeQuantity(Decimal(position.position)))
-        self.validatePositionContract(position, parsedPosition.instrument)
-
-    @unittest.skip('Exists to validate test data only')
-    @given(validPositions)
-    def test_parsedPositionConvertsToContract(self,
-                                              position: IB.Position) -> None:
-        parsedPosition = ibkr._extractPosition(position)
         self.assertEqual(parsedPosition.quantity,
                          Position.quantizeQuantity(Decimal(position.position)))
         self.validatePositionContract(position, parsedPosition.instrument)

--- a/tests/test_ibkr.py
+++ b/tests/test_ibkr.py
@@ -51,7 +51,7 @@ class TestIBKRTrades(unittest.TestCase):
         self.assertEqual(len(ts), 1)
         self.assertEqual(ts[0].date.date(), date(2019, 2, 12))
         self.assertEqual(ts[0].instrument,
-                         Stock(symbol, Currency.USD, exchange='NASDAQ'))
+                         Stock(symbol, Currency.USD, exchange='ISLAND'))
         self.assertEqual(ts[0].quantity, Decimal('17'))
         self.assertEqual(
             ts[0].amount, Cash(currency=Currency.USD,
@@ -294,7 +294,9 @@ class TestIBKRActivity(unittest.TestCase):
         self.assertEqual(
             ts[0],
             CashPayment(date=ts[0].date,
-                        instrument=Stock('TSLA', Currency.USD),
+                        instrument=Stock('TSLA',
+                                         Currency.USD,
+                                         exchange='NASDAQ'),
                         proceeds=helpers.cashUSD(Decimal('0.01'))))
 
 

--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -2,7 +2,7 @@ from bankroll.brokers import ibkr, vanguard
 from bankroll.model import AccountBalance, AccountData, Cash, Currency, Instrument, Bond, Stock, Option, OptionType, FutureOption, Future, Position, Quote, Trade
 from datetime import date
 from decimal import Decimal, ROUND_UP
-from hypothesis import assume, given, reproduce_failure
+from hypothesis import assume, given, reproduce_failure, seed
 from hypothesis.strategies import dates, decimals, from_type, integers, lists, one_of, sampled_from, text
 from typing import List, Optional, Tuple, TypeVar
 


### PR DESCRIPTION
This appears to be necessary to load futures and futures options market data on IB, though it's still `Optional` as it's not required for anything else at the moment. Resolves #40.

- [x] ~~Verify fuzz test still works as intended (run the skipped unit tests)~~ (deleted instead)
- [x] Manual testing